### PR TITLE
Add flags to prevent mob spawning in claims (and add a claim square command)

### DIFF
--- a/src/main/java/io/icker/factions/FactionsMod.java
+++ b/src/main/java/io/icker/factions/FactionsMod.java
@@ -1,17 +1,16 @@
 package io.icker.factions;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import io.icker.factions.config.Config;
 import net.fabricmc.api.ModInitializer;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class FactionsMod implements ModInitializer {
 	public static Logger LOGGER = LogManager.getLogger("Factions");
 
 	@Override
 	public void onInitialize() {
-		LOGGER.info("Initalized Factions Mod for Minecraft v1.17");
+		LOGGER.info("Initialized Factions Mod for Minecraft v1.17");
 		Config.init();
 	}
 }

--- a/src/main/java/io/icker/factions/command/BypassCommand.java
+++ b/src/main/java/io/icker/factions/command/BypassCommand.java
@@ -1,15 +1,13 @@
 package io.icker.factions.command;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-import com.mojang.brigadier.Command;
-
+import io.icker.factions.database.PlayerConfig;
+import io.icker.factions.util.Message;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
-
-import io.icker.factions.database.PlayerConfig;
-import io.icker.factions.util.Message;
 
 public class BypassCommand implements Command<ServerCommandSource> {
     @Override

--- a/src/main/java/io/icker/factions/command/ChatCommand.java
+++ b/src/main/java/io/icker/factions/command/ChatCommand.java
@@ -2,7 +2,6 @@ package io.icker.factions.command;
 
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.database.PlayerConfig;
 import io.icker.factions.database.PlayerConfig.ChatOption;
 import io.icker.factions.util.Message;

--- a/src/main/java/io/icker/factions/command/CommandRegistry.java
+++ b/src/main/java/io/icker/factions/command/CommandRegistry.java
@@ -2,10 +2,10 @@ package io.icker.factions.command;
 
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.arguments.BoolArgumentType;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Member;
 import net.minecraft.command.argument.ColorArgumentType;
@@ -114,6 +114,22 @@ public class CommandRegistry {
 			)
 			.build();
 
+		LiteralCommandNode<ServerCommandSource> allowMonsters = CommandManager
+				.literal("monsters")
+				.then(
+					CommandManager.argument("monsters", BoolArgumentType.bool())
+					.executes(ModifyCommand::allowMonsters)
+				)
+				.build();
+
+		LiteralCommandNode<ServerCommandSource> allowAnimals = CommandManager
+				.literal("animals")
+				.then(
+					CommandManager.argument("animals", BoolArgumentType.bool())
+					.executes(ModifyCommand::allowAnimals)
+				)
+				.build();
+
 		LiteralCommandNode<ServerCommandSource> invite = CommandManager
 			.literal("invite")
 			.requires(CommandRegistry::isFactionMember)
@@ -156,6 +172,20 @@ public class CommandRegistry {
 			.executes(ClaimCommand::remove)
 			.build();
 
+		LiteralCommandNode<ServerCommandSource> squareClaim = CommandManager
+			.literal("square")
+				.then(
+						CommandManager.argument("size", IntegerArgumentType.integer(1, 10)) // Max should probs be a config option
+						.executes(ClaimCommand::square)
+				)
+				.build();
+
+
+		LiteralCommandNode<ServerCommandSource> squareClaimAlias = CommandManager
+			.literal("s")
+			.redirect(squareClaim)
+			.build();
+
 		LiteralCommandNode<ServerCommandSource> removeAllClaims = CommandManager
 			.literal("all")
 			.executes(ClaimCommand::removeAll)
@@ -194,6 +224,8 @@ public class CommandRegistry {
 		modify.addChild(description);
 		modify.addChild(color);
 		modify.addChild(open);
+		modify.addChild(allowMonsters);
+		modify.addChild(allowAnimals);
 
 		factions.addChild(invite);
 		invite.addChild(listInvites);
@@ -204,6 +236,8 @@ public class CommandRegistry {
 		claim.addChild(listClaim);
 		claim.addChild(removeClaim);
 		removeClaim.addChild(removeAllClaims);
+		claim.addChild(squareClaim);
+		claim.addChild(squareClaimAlias);
 
 		factions.addChild(home);
 		home.addChild(setHome);

--- a/src/main/java/io/icker/factions/command/CreateCommand.java
+++ b/src/main/java/io/icker/factions/command/CreateCommand.java
@@ -1,14 +1,12 @@
 package io.icker.factions.command;
 
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Faction;
 import io.icker.factions.util.Message;
-
-import com.mojang.brigadier.Command;
-import com.mojang.brigadier.arguments.StringArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
@@ -26,7 +24,7 @@ public class CreateCommand implements Command<ServerCommandSource> {
 			return 0;
 		}
 
-		Faction.add(name, "No description set", Formatting.WHITE.getName(), false, Config.BASE_POWER + Config.MEMBER_POWER).addMember(player.getUuid());
+		Faction.add(name, "No description set", Formatting.WHITE.getName(), false, false, true, Config.BASE_POWER + Config.MEMBER_POWER).addMember(player.getUuid());
 		source.getServer().getPlayerManager().sendCommandTree(player);
 		
 		new Message("Successfully created faction").send(player, false);

--- a/src/main/java/io/icker/factions/command/DisbandCommand.java
+++ b/src/main/java/io/icker/factions/command/DisbandCommand.java
@@ -1,13 +1,11 @@
 package io.icker.factions.command;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
 import io.icker.factions.util.Message;
-
-import com.mojang.brigadier.Command;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;

--- a/src/main/java/io/icker/factions/command/HomeCommand.java
+++ b/src/main/java/io/icker/factions/command/HomeCommand.java
@@ -3,7 +3,6 @@ package io.icker.factions.command;
 
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Claim;
 import io.icker.factions.database.Faction;

--- a/src/main/java/io/icker/factions/command/InfoCommand.java
+++ b/src/main/java/io/icker/factions/command/InfoCommand.java
@@ -4,20 +4,18 @@ import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
 import io.icker.factions.util.Message;
-
-import java.util.ArrayList;
-import java.util.stream.Collectors;
-
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Util;
 import net.minecraft.util.UserCache;
+import net.minecraft.util.Util;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 public class InfoCommand  {
 	public static int self(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {

--- a/src/main/java/io/icker/factions/command/InviteCommand.java
+++ b/src/main/java/io/icker/factions/command/InviteCommand.java
@@ -1,12 +1,8 @@
 package io.icker.factions.command;
 
-import java.util.ArrayList;
-import java.util.stream.Collectors;
-
 import com.mojang.authlib.GameProfile;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Invite;
 import io.icker.factions.database.Member;
@@ -15,8 +11,11 @@ import net.minecraft.command.argument.EntityArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
-import net.minecraft.util.Util;
 import net.minecraft.util.UserCache;
+import net.minecraft.util.Util;
+
+import java.util.ArrayList;
+import java.util.stream.Collectors;
 
 public class InviteCommand {
 	public static int list(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {

--- a/src/main/java/io/icker/factions/command/JoinCommand.java
+++ b/src/main/java/io/icker/factions/command/JoinCommand.java
@@ -1,16 +1,14 @@
 package io.icker.factions.command;
 
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Invite;
 import io.icker.factions.event.FactionEvents;
 import io.icker.factions.util.Message;
-
-import com.mojang.brigadier.Command;
-import com.mojang.brigadier.arguments.StringArgumentType;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 

--- a/src/main/java/io/icker/factions/command/LeaveCommand.java
+++ b/src/main/java/io/icker/factions/command/LeaveCommand.java
@@ -1,15 +1,13 @@
 package io.icker.factions.command;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
 import io.icker.factions.event.FactionEvents;
 import io.icker.factions.util.Message;
-
-import com.mojang.brigadier.Command;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 

--- a/src/main/java/io/icker/factions/command/ListCommand.java
+++ b/src/main/java/io/icker/factions/command/ListCommand.java
@@ -1,16 +1,15 @@
 package io.icker.factions.command;
 
+import com.mojang.brigadier.Command;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import io.icker.factions.database.Faction;
 import io.icker.factions.util.Message;
-
-import java.util.ArrayList;
-
-import com.mojang.brigadier.Command;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
+
+import java.util.ArrayList;
 
 public class ListCommand implements Command<ServerCommandSource> {
     @Override

--- a/src/main/java/io/icker/factions/command/ModifyCommand.java
+++ b/src/main/java/io/icker/factions/command/ModifyCommand.java
@@ -4,7 +4,6 @@ import com.mojang.brigadier.arguments.BoolArgumentType;
 import com.mojang.brigadier.arguments.StringArgumentType;
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
-
 import io.icker.factions.database.Member;
 import io.icker.factions.util.Message;
 import net.minecraft.command.argument.ColorArgumentType;
@@ -43,6 +42,28 @@ public class ModifyCommand {
 
 		Member.get(player.getUuid()).getFaction().setOpen(open);
 		new Message("Successfully updated faction to  " + (open ? "open" : "closed")).send(player, false);
+		return 1;
+	}
+
+	public static int allowMonsters(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		boolean allowMonsters = BoolArgumentType.getBool(context, "monsters");
+
+		ServerCommandSource source = context.getSource();
+		ServerPlayerEntity player = source.getPlayer();
+
+		Member.get(player.getUuid()).getFaction().setAllowMonsters(allowMonsters);
+		new Message("Successfully updated faction to %s monster spawning", allowMonsters ? "allow" : "deny").send(player, false);
+		return 1;
+	}
+
+	public static int allowAnimals(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		boolean allowAnimals = BoolArgumentType.getBool(context, "animals");
+
+		ServerCommandSource source = context.getSource();
+		ServerPlayerEntity player = source.getPlayer();
+
+		Member.get(player.getUuid()).getFaction().setAllowAnimals(allowAnimals);
+		new Message("Successfully updated faction to %s monster spawning", allowAnimals ? "allow" : "deny").send(player, false);
 		return 1;
 	}
 }

--- a/src/main/java/io/icker/factions/config/Parser.java
+++ b/src/main/java/io/icker/factions/config/Parser.java
@@ -1,16 +1,15 @@
 package io.icker.factions.config;
 
-import java.io.File;
-import java.io.FileReader;
-import java.io.IOException;
-
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonArray;
 import com.google.gson.JsonObject;
-
 import io.icker.factions.FactionsMod;
 import net.fabricmc.loader.api.FabricLoader;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.IOException;
 
 public class Parser {
     private static final File factionDir = FabricLoader.getInstance().getGameDir().resolve("factions").toFile();

--- a/src/main/java/io/icker/factions/database/Database.java
+++ b/src/main/java/io/icker/factions/database/Database.java
@@ -1,10 +1,10 @@
 package io.icker.factions.database;
 
+import io.icker.factions.FactionsMod;
+
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-
-import io.icker.factions.FactionsMod;
 
 public class Database {
     public static Connection con;
@@ -18,6 +18,8 @@ public class Database {
                     description VARCHAR(255),
                     color VARCHAR(255),
                     open BOOLEAN,
+                    allowMonsters BOOLEAN,
+                    allowAnimals BOOLEAN,
                     power INTEGER
                 );
 

--- a/src/main/java/io/icker/factions/database/Faction.java
+++ b/src/main/java/io/icker/factions/database/Faction.java
@@ -1,15 +1,17 @@
 package io.icker.factions.database;
 
+import net.minecraft.util.Formatting;
+
 import java.util.ArrayList;
 import java.util.UUID;
-
-import net.minecraft.util.Formatting;
 
 public class Faction {
     public String name;
     public String description;
     public Formatting color;
     public boolean open;
+    public boolean allowMonsters;
+    public boolean allowAnimals;
     public int power;
 
     public static Faction get(String name) {
@@ -18,16 +20,16 @@ public class Faction {
             .executeQuery();
 
         if (!query.success) return null;
-        return new Faction(name, query.getString("description"), Formatting.byName(query.getString("color")), query.getBool("open"), query.getInt("power"));
+        return new Faction(name, query.getString("description"), Formatting.byName(query.getString("color")), query.getBool("open"), query.getBool("allowMonsters"), query.getBool("allowAnimals"), query.getInt("power"));
     }
 
-    public static Faction add(String name, String description, String color, boolean open, int power) {
-        Query query = new Query("INSERT INTO Faction VALUES (?, ?, ?, ?, ?);")
-            .set(name, description, color, open, power)
+    public static Faction add(String name, String description, String color, boolean open, boolean allowMonsters, boolean allowAnimals, int power) {
+        Query query = new Query("INSERT INTO Faction VALUES (?, ?, ?, ?, ?, ?, ?);")
+            .set(name, description, color, open, allowMonsters, allowAnimals, power)
             .executeUpdate();
 
         if (!query.success) return null;
-        return new Faction(name, description, Formatting.byName(color), open, power);
+        return new Faction(name, description, Formatting.byName(color), open, allowMonsters, allowAnimals, power);
     }
 
     public static ArrayList<Faction> all() {
@@ -38,17 +40,19 @@ public class Faction {
         if (!query.success) return factions;
 
         while (query.next()) {
-            factions.add(new Faction(query.getString("name"), query.getString("description"), Formatting.byName(query.getString("color")), query.getBool("open"), query.getInt("power")));
+            factions.add(new Faction(query.getString("name"), query.getString("description"), Formatting.byName(query.getString("color")), query.getBool("open"), query.getBool("allowMonsters"), query.getBool("allowAnimals"), query.getInt("power")));
         }
         return factions;
     }
 
-    public Faction(String name, String description, Formatting color, boolean open, int power) {
+    public Faction(String name, String description, Formatting color, boolean open, boolean allowMonsters, boolean allowAnimals, int power) {
         this.name = name;
         this.description = description;
         this.color = color;
         this.open = open;
         this.power = power;
+        this.allowMonsters = allowMonsters;
+        this.allowAnimals = allowAnimals;
     }
 
     public void setDescription(String description) {
@@ -67,6 +71,18 @@ public class Faction {
         new Query("UPDATE Faction SET open = ? WHERE name = ?;")
             .set(open, name)
             .executeUpdate();
+    }
+
+    public void setAllowMonsters(boolean allowMonsters) {
+        new Query("UPDATE Faction SET allowMonsters = ? WHERE name = ?;")
+                .set(allowMonsters, name)
+                .executeUpdate();
+    }
+
+    public void setAllowAnimals(boolean allowAnimals) {
+        new Query("UPDATE Faction SET allowAnimals = ? WHERE name = ?;")
+                .set(allowAnimals, name)
+                .executeUpdate();
     }
 
     public void setPower(int power) {

--- a/src/main/java/io/icker/factions/database/Query.java
+++ b/src/main/java/io/icker/factions/database/Query.java
@@ -1,10 +1,10 @@
 package io.icker.factions.database;
 
+import io.icker.factions.FactionsMod;
+
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-
-import io.icker.factions.FactionsMod;
 
 // TODO: stmt.close() on gets
 public class Query {

--- a/src/main/java/io/icker/factions/event/ChatEvents.java
+++ b/src/main/java/io/icker/factions/event/ChatEvents.java
@@ -1,7 +1,5 @@
 package io.icker.factions.event;
 
-import java.util.UUID;
-
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
 import io.icker.factions.database.PlayerConfig;
@@ -9,6 +7,8 @@ import io.icker.factions.database.PlayerConfig.ChatOption;
 import io.icker.factions.util.Message;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
+
+import java.util.UUID;
 
 public class ChatEvents {
     public static void handleMessage(ServerPlayerEntity sender, String message) {

--- a/src/main/java/io/icker/factions/event/EntityEvents.java
+++ b/src/main/java/io/icker/factions/event/EntityEvents.java
@@ -1,0 +1,156 @@
+package io.icker.factions.event;
+
+import io.icker.factions.database.Claim;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+
+import java.util.HashSet;
+import java.util.Set;
+
+public class EntityEvents {
+    private static final Set<EntityType<?>> MONSTERS = new HashSet<>();
+    private static final Set<EntityType<?>> ANIMALS = new HashSet<>();
+
+    /**
+     * Called when an entity tries to spawn.
+     * @param entity The entity that is trying to spawn.
+     * @return True if the entity can spawn. False if it cant.
+     */
+    public static boolean entitySpawn(Entity entity) {
+        EntityType<?> type = entity.getType();
+        if (MONSTERS.contains(type)) {
+            Claim claim = Claim.get(entity.getChunkPos().x, entity.getChunkPos().z, entity.getEntityWorld().getRegistryKey().getValue().toString());
+            if (claim == null)
+                return true;
+
+            return claim.getFaction().allowMonsters;
+        } else if (ANIMALS.contains(type)) {
+            Claim claim = Claim.get(entity.getChunkPos().x, entity.getChunkPos().z, entity.getEntityWorld().getRegistryKey().getValue().toString());
+            if (claim == null)
+                return true;
+
+            return claim.getFaction().allowAnimals;
+        }
+
+        return true;
+    }
+
+    static {
+        MONSTERS.add(EntityType.BLAZE);
+        MONSTERS.add(EntityType.CAVE_SPIDER);
+        MONSTERS.add(EntityType.CREEPER);
+        MONSTERS.add(EntityType.DROWNED);
+        MONSTERS.add(EntityType.ELDER_GUARDIAN); // Exception for (mini) boss mobs in the rule maybe?
+        MONSTERS.add(EntityType.ENDER_DRAGON); // Exception for (mini) boss mobs in the rule maybe?
+        MONSTERS.add(EntityType.ENDERMAN);
+        MONSTERS.add(EntityType.ENDERMITE);
+        MONSTERS.add(EntityType.EVOKER);
+        MONSTERS.add(EntityType.GHAST);
+        MONSTERS.add(EntityType.GIANT); // Do we even need to care?
+        MONSTERS.add(EntityType.GUARDIAN);
+        MONSTERS.add(EntityType.HOGLIN);
+        MONSTERS.add(EntityType.HUSK);
+        MONSTERS.add(EntityType.ILLUSIONER);
+        MONSTERS.add(EntityType.MAGMA_CUBE);
+        MONSTERS.add(EntityType.PHANTOM);
+        MONSTERS.add(EntityType.PIGLIN);
+        MONSTERS.add(EntityType.PIGLIN_BRUTE);
+        MONSTERS.add(EntityType.PILLAGER);
+        MONSTERS.add(EntityType.RAVAGER);
+        MONSTERS.add(EntityType.SHULKER);
+        MONSTERS.add(EntityType.SILVERFISH);
+        MONSTERS.add(EntityType.SKELETON);
+        MONSTERS.add(EntityType.SKELETON_HORSE);
+        MONSTERS.add(EntityType.SLIME);
+        MONSTERS.add(EntityType.SPIDER);
+        MONSTERS.add(EntityType.STRAY);
+        MONSTERS.add(EntityType.VEX);
+        MONSTERS.add(EntityType.VINDICATOR);
+        MONSTERS.add(EntityType.WITCH);
+        MONSTERS.add(EntityType.WITHER); // Exception for (mini) boss mobs in the rule maybe?
+        MONSTERS.add(EntityType.WITHER_SKELETON);
+        MONSTERS.add(EntityType.ZOGLIN);
+        MONSTERS.add(EntityType.ZOMBIE);
+        MONSTERS.add(EntityType.ZOMBIE_HORSE);
+        MONSTERS.add(EntityType.ZOMBIE_VILLAGER);
+        MONSTERS.add(EntityType.ZOMBIFIED_PIGLIN);
+
+        ANIMALS.add(EntityType.AXOLOTL);
+        ANIMALS.add(EntityType.BAT);
+        ANIMALS.add(EntityType.BEE); // Might cause side effects of bees not coming out of hives/nests anymore
+        ANIMALS.add(EntityType.CAT);
+        ANIMALS.add(EntityType.CHICKEN);
+        ANIMALS.add(EntityType.COD);
+        ANIMALS.add(EntityType.COW);
+        ANIMALS.add(EntityType.DOLPHIN);
+        ANIMALS.add(EntityType.DONKEY);
+        ANIMALS.add(EntityType.FOX);
+        ANIMALS.add(EntityType.GLOW_SQUID);
+        ANIMALS.add(EntityType.GOAT);
+        ANIMALS.add(EntityType.HORSE);
+        ANIMALS.add(EntityType.IRON_GOLEM);
+        ANIMALS.add(EntityType.LLAMA);
+        ANIMALS.add(EntityType.MULE);
+        ANIMALS.add(EntityType.MOOSHROOM);
+        ANIMALS.add(EntityType.OCELOT);
+        ANIMALS.add(EntityType.PANDA);
+        ANIMALS.add(EntityType.PARROT);
+        ANIMALS.add(EntityType.PIG);
+        ANIMALS.add(EntityType.POLAR_BEAR);
+        ANIMALS.add(EntityType.PUFFERFISH);
+        ANIMALS.add(EntityType.RABBIT);
+        ANIMALS.add(EntityType.SALMON);
+        ANIMALS.add(EntityType.SHEEP);
+        ANIMALS.add(EntityType.SNOW_GOLEM);
+        ANIMALS.add(EntityType.SQUID);
+        ANIMALS.add(EntityType.STRIDER);
+        ANIMALS.add(EntityType.TRADER_LLAMA);
+        ANIMALS.add(EntityType.TROPICAL_FISH);
+        ANIMALS.add(EntityType.TURTLE);
+        ANIMALS.add(EntityType.VILLAGER);
+        ANIMALS.add(EntityType.WANDERING_TRADER);
+        ANIMALS.add(EntityType.WOLF);
+
+        /*
+        AREA_EFFECT_CLOUD
+        ARMOR_STAND
+        ARROW
+        BOAT
+        DRAGON_FIREBALL
+        END_CRYSTAL
+        EVOKER_FANGS
+        EXPERIENCE_ORB
+        EYE_OF_ENDER
+        FALLING_BLOCK
+        FIREWORK_ROCKET
+        GLOW_ITEM_FRAME
+        ITEM
+        ITEM_FRAME
+        FIREBALL
+        LEASH_KNOT
+        LIGHTNING_BOLT
+        LLAMA_SPIT
+        MARKER
+        MINECART
+        CHEST_MINECART
+        COMMAND_BLOCK_MINECART
+        FURNACE_MINECART
+        HOPPER_MINECART
+        SPAWNER_MINECART
+        TNT_MINECART
+        PAINTING
+        TNT
+        SHULKER_BULLET
+        SMALL_FIREBALL
+        SNOWBALL
+        SPECTRAL_ARROW
+        EGG
+        ENDER_PEARL
+        EXPERIENCE_BOTTLE
+        TRIDENT
+        WITHER_SKULL
+        PLAYER
+        FISHING_BOBBER
+         */
+    }
+}

--- a/src/main/java/io/icker/factions/event/PlayerInteractEvents.java
+++ b/src/main/java/io/icker/factions/event/PlayerInteractEvents.java
@@ -5,24 +5,23 @@ import io.icker.factions.database.Claim;
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
 import io.icker.factions.database.PlayerConfig;
-import io.icker.factions.util.Message;
 import io.icker.factions.mixin.BucketItemMixin;
 import io.icker.factions.mixin.ItemMixin;
-
+import io.icker.factions.util.Message;
+import net.minecraft.fluid.Fluid;
+import net.minecraft.fluid.Fluids;
+import net.minecraft.item.BucketItem;
+import net.minecraft.item.Item;
+import net.minecraft.item.ItemStack;
+import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.util.math.ChunkPos;
-import net.minecraft.world.World;
 import net.minecraft.world.RaycastContext;
 import net.minecraft.world.RaycastContext.FluidHandling;
-import net.minecraft.fluid.Fluid;
-import net.minecraft.fluid.Fluids;
-import net.minecraft.item.Item;
-import net.minecraft.item.BucketItem;
-import net.minecraft.item.ItemStack;
-import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
+import net.minecraft.world.World;
 
 public class PlayerInteractEvents {
     public static boolean preventInteract(ServerPlayerEntity player, World world, BlockHitResult result) {

--- a/src/main/java/io/icker/factions/mixin/BucketItemMixin.java
+++ b/src/main/java/io/icker/factions/mixin/BucketItemMixin.java
@@ -1,10 +1,9 @@
 package io.icker.factions.mixin;
 
+import net.minecraft.fluid.Fluid;
+import net.minecraft.item.BucketItem;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.gen.Accessor;
-
-import net.minecraft.item.BucketItem;
-import net.minecraft.fluid.Fluid;
 
 @Mixin(BucketItem.class)
 public interface BucketItemMixin {

--- a/src/main/java/io/icker/factions/mixin/CommandManagerMixin.java
+++ b/src/main/java/io/icker/factions/mixin/CommandManagerMixin.java
@@ -1,16 +1,15 @@
 package io.icker.factions.mixin;
 
 import com.mojang.brigadier.CommandDispatcher;
+import io.icker.factions.command.CommandRegistry;
+import net.minecraft.server.command.CommandManager;
+import net.minecraft.server.command.ServerCommandSource;
 import org.spongepowered.asm.mixin.Final;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import io.icker.factions.command.CommandRegistry;
-import net.minecraft.server.command.CommandManager;
-import net.minecraft.server.command.ServerCommandSource;
 
 @Mixin(CommandManager.class)
 public abstract class CommandManagerMixin {

--- a/src/main/java/io/icker/factions/mixin/ItemMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ItemMixin.java
@@ -1,13 +1,12 @@
 package io.icker.factions.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.gen.Invoker;
-
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.Item;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.world.RaycastContext;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
 
 @Mixin(Item.class)
 public interface ItemMixin {

--- a/src/main/java/io/icker/factions/mixin/MinecraftServerMixin.java
+++ b/src/main/java/io/icker/factions/mixin/MinecraftServerMixin.java
@@ -1,12 +1,11 @@
 package io.icker.factions.mixin;
 
+import io.icker.factions.event.ServerEvents;
+import net.minecraft.server.MinecraftServer;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import io.icker.factions.event.ServerEvents;
-import net.minecraft.server.MinecraftServer;
 
 @Mixin(MinecraftServer.class)
 public abstract class MinecraftServerMixin {

--- a/src/main/java/io/icker/factions/mixin/ServerPlayNetworkManagerMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerPlayNetworkManagerMixin.java
@@ -1,18 +1,16 @@
 package io.icker.factions.mixin;
 
+import io.icker.factions.event.ChatEvents;
 import net.minecraft.network.MessageType;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.server.filter.TextStream;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.text.Text;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Redirect;
-
-import io.icker.factions.event.ChatEvents;
 
 import java.util.UUID;
 import java.util.function.Function;

--- a/src/main/java/io/icker/factions/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerPlayerEntityMixin.java
@@ -1,20 +1,18 @@
 package io.icker.factions.mixin;
 
+import io.icker.factions.config.Config;
+import io.icker.factions.event.FactionEvents;
+import io.icker.factions.event.PlayerInteractEvents;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.world.World;
-
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import io.icker.factions.config.Config;
-import io.icker.factions.event.FactionEvents;
-import io.icker.factions.event.PlayerInteractEvents;
 
 @Mixin(ServerPlayerEntity.class)
 public abstract class ServerPlayerEntityMixin extends LivingEntity {

--- a/src/main/java/io/icker/factions/mixin/ServerPlayerInteractionManagerMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerPlayerInteractionManagerMixin.java
@@ -1,11 +1,5 @@
 package io.icker.factions.mixin;
 
-import org.spongepowered.asm.mixin.Mixin;
-import org.spongepowered.asm.mixin.Shadow;
-import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
-
 import io.icker.factions.event.PlayerInteractEvents;
 import net.minecraft.item.ItemStack;
 import net.minecraft.server.network.ServerPlayerEntity;
@@ -16,6 +10,11 @@ import net.minecraft.util.Hand;
 import net.minecraft.util.hit.BlockHitResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 @Mixin(ServerPlayerInteractionManager.class)
 public class ServerPlayerInteractionManagerMixin {

--- a/src/main/java/io/icker/factions/mixin/ServerWorldMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerWorldMixin.java
@@ -1,0 +1,19 @@
+package io.icker.factions.mixin;
+
+import io.icker.factions.event.EntityEvents;
+import net.minecraft.entity.Entity;
+import net.minecraft.server.world.ServerWorld;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(ServerWorld.class)
+public class ServerWorldMixin {
+
+    @Inject(method = "spawnEntity", at = @At("HEAD"), cancellable = true)
+    public void spawnEntity(Entity entity, CallbackInfoReturnable<Boolean> cir) {
+        if (!EntityEvents.entitySpawn(entity))
+            cir.setReturnValue(false);
+    }
+}

--- a/src/main/resources/factions.mixins.json
+++ b/src/main/resources/factions.mixins.json
@@ -4,13 +4,14 @@
   "package": "io.icker.factions.mixin",
   "compatibilityLevel": "JAVA_16",
   "mixins": [
-    "ItemMixin",
     "BucketItemMixin",
     "CommandManagerMixin",
+    "ItemMixin",
     "MinecraftServerMixin",
     "ServerPlayerEntityMixin",
+    "ServerPlayerInteractionManagerMixin",
     "ServerPlayNetworkManagerMixin",
-    "ServerPlayerInteractionManagerMixin"
+    "ServerWorldMixin"
   ],
   "server": [],
   "injectors": {


### PR DESCRIPTION
# Changes
- Add an allowMonsters flag to prevent hostile mob spawning in claims (defaults to false)
- Add an allowAnimals flag to prevent friendly mob spawning in claims (defaults to true)
- Add the `/f claim square [size]` command to claim a larger area at once.

# Discussion
This PR introduces database changes to the `factions` table (the addition of the two flags). How should database migration be handled? Should flags maybe be removed from the `factions` table altogether and be moved into their own table? 