### PR TITLE
Config rework.

### DIFF
--- a/src/main/java/io/icker/factions/FactionsMod.java
+++ b/src/main/java/io/icker/factions/FactionsMod.java
@@ -1,6 +1,9 @@
 package io.icker.factions;
 
 import net.minecraft.server.PlayerManager;
+
+import java.io.IOException;
+
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -22,7 +25,11 @@ public class FactionsMod implements ModInitializer {
 	@Override
 	public void onInitialize() {
 		LOGGER.info("Initalized Factions Mod for Minecraft v1.18");
-		Config.init();
+		try {
+			Config.init();
+		} catch (IOException e) {
+			e.printStackTrace();
+		}
 		if (PermissionsWrapper.exists()) {
 			LOGGER.info("Permissions Mod was found");
 		}

--- a/src/main/java/io/icker/factions/command/InfoCommand.java
+++ b/src/main/java/io/icker/factions/command/InfoCommand.java
@@ -20,8 +20,6 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.Util;
 import net.minecraft.util.UserCache;
 
-import io.icker.factions.FactionsMod;
-
 public class InfoCommand  {
 	public static int self(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
         ServerCommandSource source = context.getSource();

--- a/src/main/java/io/icker/factions/command/MapCommand.java
+++ b/src/main/java/io/icker/factions/command/MapCommand.java
@@ -6,7 +6,6 @@ import io.icker.factions.database.Claim;
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
 import io.icker.factions.util.Message;
-import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.server.world.ServerWorld;

--- a/src/main/java/io/icker/factions/config/Config.java
+++ b/src/main/java/io/icker/factions/config/Config.java
@@ -9,8 +9,7 @@ import java.io.IOException;
 // import java.util.ArrayList;
 
 public class Config {
-    private static final String fileName = "config.json";
-    private static final String[] directories = {"factions", "config"};
+    private static final String[] filePaths = {"factions/config.json", "config/factions.json"};
     private static final Integer version = 1;
 
     public static enum HomeOptions {
@@ -60,7 +59,7 @@ public class Config {
     // }
 
     public static void init() throws IOException {
-        FileParser parser = new FileParser(version, fileName, directories);
+        FileParser parser = new FileParser(version, filePaths);
 
         // parser.getArray("zones").forEach(object -> {
         //     try {

--- a/src/main/java/io/icker/factions/config/Config.java
+++ b/src/main/java/io/icker/factions/config/Config.java
@@ -1,18 +1,24 @@
 package io.icker.factions.config;
 
-import com.google.gson.JsonObject;
-import io.icker.factions.config.Zone.Type;
+// import com.google.gson.JsonArray;
+// import com.google.gson.JsonPrimitive;
 
-import java.util.ArrayList;
+// import io.icker.factions.config.Zone.Type;
+
+import java.io.IOException;
+// import java.util.ArrayList;
 
 public class Config {
+    private static final String fileName = "config.json";
+    private static final String[] directories = {"factions", "config"};
+
     public static enum HomeOptions {
         ANYWHERE,
         CLAIMS,
-        DISABLED;
+        DISABLED
     }
 
-    public static ArrayList<Zone> ZONES = new ArrayList<Zone>();
+    // public static ArrayList<Zone> ZONES = new ArrayList<Zone>();
     public static int BASE_POWER;
     public static int MEMBER_POWER;
     public static int CLAIM_WEIGHT;
@@ -26,42 +32,70 @@ public class Config {
     public static boolean ZONE_MESSAGE;
     public static boolean FRIENDLY_FIRE;
 
-    public static void init() {
-        JsonObject obj = Parser.load();
-        
-        Parser.asArray(obj, "zones").forEach(e -> {
-            if (!e.isJsonObject()) return;
-            JsonObject zoneObj = e.getAsJsonObject();
-            
-            Type type = Parser.asEnum(zoneObj, "type", Type.class, Type.DEFAULT);
-            String message = Parser.asString(zoneObj, "message", "No fail message set");
+    // private static final Constraint asConstraint(ObjectParser parser) throws IOException {
+    //     Constraint con = new Constraint();
 
-            Zone zone = new Zone(type, message);
-            zone.x = Parser.asConstraint(zoneObj, "x");
-            zone.z = Parser.asConstraint(zoneObj, "z");
+    //     con.equal = parser.getInteger("==", null);
+    //     con.notEqual = parser.getInteger("!=", null);
+    //     con.lessThan = parser.getInteger("<", null);
+    //     con.lessThanOrEqual = parser.getInteger("<=", null);
+    //     con.greaterThan = parser.getInteger(">", null);
+    //     con.greaterThanOrEqual = parser.getInteger(">=", null);
 
-            JsonObject dimensions = Parser.asObject(zoneObj, "dimensions");
-            zone.includedDimensions = Parser.asDimensionList(dimensions, "include");
-            zone.excludedDimensions = Parser.asDimensionList(dimensions, "exclude");
+    //     return con;
+    // }
 
-           ZONES.add(zone);
-        });
+    // private static final ArrayList<String> asDimensionList(JsonArray array) {
+    //     ArrayList<String> list = new ArrayList<String>();
 
-        BASE_POWER = Parser.asInt(obj, "basePower", 20);
-        MEMBER_POWER = Parser.asInt(obj, "memberPower", 20);
-        CLAIM_WEIGHT = Parser.asInt(obj, "claimWeight", 5);
-        MAX_FACTION_SIZE = Parser.asInt(obj, "maxFactionSize", /*-1*/4);
-        SAFE_TICKS_TO_WARP = Parser.asInt(obj, "safeTicksToWarp", 5 * 20);
-        POWER_DEATH_PENALTY = Parser.asInt(obj, "powerDeathPenalty", 10);
-        TICKS_FOR_POWER = Parser.asInt(obj, "ticksForPower", 10 * 60 * 20);
-        TICKS_FOR_POWER_REWARD = Parser.asInt(obj, "ticksForPowerReward", 1);
-        REQUIRED_BYPASS_LEVEL = Parser.asInt(obj, "requiredBypassLevel", 2);
-        HOME = Parser.asEnum(obj, "home", HomeOptions.class, HomeOptions.CLAIMS);
-        ZONE_MESSAGE = Parser.asBool(obj, "zoneMessageEnabled", true);
-        FRIENDLY_FIRE = Parser.asBool(obj, "friendlyFireEnabled", false);
+    //     array.forEach(e -> {
+    //         if (e.isJsonPrimitive()) {
+    //             JsonPrimitive primitive = e.getAsJsonPrimitive();
+    //             if (primitive.isString()) list.add(primitive.getAsString());
+    //         }
+    //     });
+
+    //     return list;
+    // }
+
+    public static void init() throws IOException {
+        FileParser parser = new FileParser(1, fileName, directories);
+
+        // parser.getArray("zones").forEach(object -> {
+        //     try {
+        //         if (!object.isJsonObject()) return;
+        //         ObjectParser zoneParser = new ObjectParser(object.getAsJsonObject(), parser);
+                
+        //         Type type = zoneParser.getEnum("type", Type.class, "DEFAULT");
+        //         String message = zoneParser.getString("message", "No fail message set");
+
+        //         Zone zone = new Zone(type, message);
+        //         zone.x = asConstraint(zoneParser.getParser("x"));
+        //         zone.z = asConstraint(zoneParser.getParser("z"));
+
+        //         ObjectParser dimensions = zoneParser.getParser("dimensions");
+        //         zone.includedDimensions = asDimensionList(dimensions.getArray("include"));
+        //         zone.excludedDimensions = asDimensionList(dimensions.getArray("exclude"));
+
+        //         ZONES.add(zone);
+        //     } catch (IOException e) {}
+        // });
+
+        BASE_POWER = parser.getInteger("basePower", 20);
+        MEMBER_POWER = parser.getInteger("memberPower", 20);
+        CLAIM_WEIGHT = parser.getInteger("claimWeight", 5);
+        MAX_FACTION_SIZE = parser.getInteger("maxFactionSize", -1);
+        SAFE_TICKS_TO_WARP = parser.getInteger("safeTicksToWarp", 1000);
+        POWER_DEATH_PENALTY = parser.getInteger("powerDeathPenalty", 10);
+        TICKS_FOR_POWER = parser.getInteger("ticksForPower", 12000);
+        TICKS_FOR_POWER_REWARD = parser.getInteger("ticksForPowerReward", 1);
+        REQUIRED_BYPASS_LEVEL = parser.getInteger("requiredBypassLevel", 2);
+        HOME = parser.getEnum("home", HomeOptions.class, "CLAIMS");
+        ZONE_MESSAGE = parser.getBoolean("zoneMessageEnabled", true);
+        FRIENDLY_FIRE = parser.getBoolean("friendlyFireEnabled", false);
     }
 
-    public static Zone getZone(String dimension, int x, int z) {
-        return ZONES.stream().filter(zone -> zone.isApplicable(dimension, x, z)).findFirst().orElse(new Zone(Type.DEFAULT, "No Zones Set"));
-    };
+    // public static Zone getZone(String dimension, int x, int z) {
+    //     return ZONES.stream().filter(zone -> zone.isApplicable(dimension, x, z)).findFirst().orElse(new Zone(Type.DEFAULT, "No Zones Set"));
+    // };
 }

--- a/src/main/java/io/icker/factions/config/Config.java
+++ b/src/main/java/io/icker/factions/config/Config.java
@@ -11,6 +11,7 @@ import java.io.IOException;
 public class Config {
     private static final String fileName = "config.json";
     private static final String[] directories = {"factions", "config"};
+    private static final Integer version = 1;
 
     public static enum HomeOptions {
         ANYWHERE,
@@ -59,7 +60,7 @@ public class Config {
     // }
 
     public static void init() throws IOException {
-        FileParser parser = new FileParser(1, fileName, directories);
+        FileParser parser = new FileParser(version, fileName, directories);
 
         // parser.getArray("zones").forEach(object -> {
         //     try {

--- a/src/main/java/io/icker/factions/config/FileParser.java
+++ b/src/main/java/io/icker/factions/config/FileParser.java
@@ -13,24 +13,23 @@ import io.icker.factions.FactionsMod;
 public final class FileParser extends Parser {
     protected File configFile;
 
-    protected static File getFile(String fileName, String[] directories) throws IOException {
-        for (String dir : directories) {
-            File file = new File(dir, fileName);
+    protected static File getFile(String[] filePaths) throws IOException {
+        for (String path : filePaths) {
+            File file = new File(path);
 
             if (file.exists()) {
                 return file;
             }
         }
 
-        File dir = new File(directories[0] + "/");
-        dir.mkdir();
-        File file = new File(dir, fileName);
+        File file = new File(filePaths[0]);
+        file.getParentFile().mkdirs();
         file.createNewFile();
         return file;
     }
 
-    public FileParser(Integer version, String fileName, String[] directories) throws IOException {
-        this.configFile = getFile(fileName, directories);
+    public FileParser(Integer version, String[] filePaths) throws IOException {
+        this.configFile = getFile(filePaths);
         FileReader reader = new FileReader(this.configFile);
         this.object = GSON.fromJson(reader, JsonObject.class);
         if (this.object == null) {
@@ -41,10 +40,6 @@ public final class FileParser extends Parser {
         if (this.getInteger("version", version) != version) {
             FactionsMod.LOGGER.error(String.format("Config file incompatible (requires version %d)", version));
         }
-    }
-
-    public FileParser(int version, String fileName) throws IOException {
-        this(version, fileName, new String[]{"config"});
     }
 
     protected void update() throws IOException {

--- a/src/main/java/io/icker/factions/config/FileParser.java
+++ b/src/main/java/io/icker/factions/config/FileParser.java
@@ -1,0 +1,60 @@
+package io.icker.factions.config;
+
+import java.io.File;
+import java.io.FileReader;
+import java.io.FileWriter;
+import java.io.IOException;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+import io.icker.factions.FactionsMod;
+
+public final class FileParser extends Parser {
+    protected File configFile;
+
+    protected static File getFile(String fileName, String[] directories) throws IOException {
+        for (String dir : directories) {
+            File file = new File(dir, fileName);
+
+            if (file.exists()) {
+                return file;
+            }
+        }
+
+        File dir = new File(directories[0] + "/");
+        dir.mkdir();
+        File file = new File(dir, fileName);
+        file.createNewFile();
+        return file;
+    }
+
+    public FileParser(Integer version, String fileName, String[] directories) throws IOException {
+        this.configFile = getFile(fileName, directories);
+        FileReader reader = new FileReader(this.configFile);
+        this.object = GSON.fromJson(reader, JsonObject.class);
+        if (this.object == null) {
+            this.object = new JsonObject();
+        }
+        reader.close();
+
+        if (this.getInteger("version", version) != version) {
+            FactionsMod.LOGGER.error(String.format("Config file incompatible (requires version %d)", version));
+        }
+    }
+
+    public FileParser(int version, String fileName) throws IOException {
+        this(version, fileName, new String[]{"config"});
+    }
+
+    protected void update() throws IOException {
+        FileWriter writer = new FileWriter(this.configFile);
+        writer.write(GSON.toJson(this.object));
+        writer.close();
+    }
+
+    protected void create(String key, JsonElement fallback) throws IOException {
+        super.create(key, fallback);
+        update();
+    }
+}

--- a/src/main/java/io/icker/factions/config/ObjectParser.java
+++ b/src/main/java/io/icker/factions/config/ObjectParser.java
@@ -1,0 +1,20 @@
+package io.icker.factions.config;
+
+import java.io.IOException;
+
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+
+public final class ObjectParser extends Parser {
+    protected Parser parent;
+
+    public ObjectParser(JsonObject object, Parser parent) throws IOException {
+        this.object = object;
+        this.parent = parent;
+    }
+
+    protected void create(String key, JsonElement fallback) throws IOException {
+        super.create(key, fallback);
+        this.parent.update();
+    }
+}

--- a/src/main/java/io/icker/factions/database/Claim.java
+++ b/src/main/java/io/icker/factions/database/Claim.java
@@ -1,7 +1,6 @@
 package io.icker.factions.database;
 
 import io.icker.factions.FactionsMod;
-import io.icker.factions.util.DynmapWrapper;
 
 public class Claim {
     public int x;

--- a/src/main/java/io/icker/factions/database/Faction.java
+++ b/src/main/java/io/icker/factions/database/Faction.java
@@ -6,7 +6,6 @@ import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
 

--- a/src/main/java/io/icker/factions/event/FactionEvents.java
+++ b/src/main/java/io/icker/factions/event/FactionEvents.java
@@ -3,14 +3,10 @@ package io.icker.factions.event;
 import io.icker.factions.FactionsMod;
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Faction;
-import io.icker.factions.database.Claim;
 import io.icker.factions.database.Member;
 import io.icker.factions.util.Message;
 import net.minecraft.network.packet.s2c.play.PlayerListS2CPacket;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.server.world.ServerWorld;
-import net.minecraft.util.math.ChunkPos;
-import net.minecraft.util.Formatting;
 
 import java.util.Collection;
 

--- a/src/main/java/io/icker/factions/event/PlayerInteractEvents.java
+++ b/src/main/java/io/icker/factions/event/PlayerInteractEvents.java
@@ -1,6 +1,5 @@
 package io.icker.factions.event;
 
-import io.icker.factions.FactionsMod;
 import io.icker.factions.config.Config;
 import io.icker.factions.database.Claim;
 import io.icker.factions.database.Faction;
@@ -28,7 +27,6 @@ import net.minecraft.item.Item;
 import net.minecraft.item.BucketItem;
 import net.minecraft.item.ItemStack;
 import net.minecraft.network.packet.s2c.play.BlockUpdateS2CPacket;
-import java.util.UUID;
 
 public class PlayerInteractEvents {
     public static boolean preventInteract(ServerPlayerEntity player, World world, BlockHitResult result) {

--- a/src/main/java/io/icker/factions/mixin/ServerPlayNetworkHandlerMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerPlayNetworkHandlerMixin.java
@@ -1,6 +1,5 @@
 package io.icker.factions.mixin;
 
-import io.icker.factions.FactionsMod;
 import net.minecraft.network.packet.c2s.play.PlayerMoveC2SPacket;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
@@ -8,8 +7,6 @@ import org.spongepowered.asm.mixin.injection.Inject;
 import net.minecraft.server.network.ServerPlayNetworkHandler;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import io.icker.factions.event.PlayerInteractEvents;
-
-import net.minecraft.client.gui.hud.InGameHud;
 
 @Mixin(ServerPlayNetworkHandler.class)
 public class ServerPlayNetworkHandlerMixin {

--- a/src/main/java/io/icker/factions/mixin/ServerPlayerEntityMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerPlayerEntityMixin.java
@@ -1,13 +1,11 @@
 package io.icker.factions.mixin;
 
-import io.icker.factions.FactionsMod;
 import io.icker.factions.util.Message;
 import net.minecraft.entity.Entity;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LivingEntity;
 import net.minecraft.entity.damage.DamageSource;
 import net.minecraft.server.network.ServerPlayerEntity;
-import net.minecraft.text.LiteralText;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
 import net.minecraft.world.World;
@@ -19,9 +17,7 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
 
 import io.icker.factions.config.Config;
-import io.icker.factions.database.PlayerConfig;
 import io.icker.factions.database.Member;
-import io.icker.factions.database.Ally;
 import io.icker.factions.database.Faction;
 import io.icker.factions.event.FactionEvents;
 import io.icker.factions.event.PlayerInteractEvents;

--- a/src/main/java/io/icker/factions/util/DynmapWrapper.java
+++ b/src/main/java/io/icker/factions/util/DynmapWrapper.java
@@ -7,14 +7,12 @@ import org.dynmap.markers.MarkerAPI;
 import org.dynmap.markers.MarkerSet;
 import org.dynmap.markers.AreaMarker;
 
-import io.icker.factions.FactionsMod;
 import io.icker.factions.database.Ally;
 
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Claim;
 
 import java.util.ArrayList;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 import net.minecraft.util.math.ChunkPos;


### PR DESCRIPTION
This completely rewrites the config parser (also cleans up unnecessary imports).
Fixes #33.

The zone handling mechanisms for the config have been mildly rewritten, but integration with the rest of the code-base is still identical. Additionally, as zones are not implemented yet, this doesn't matter much. All the zone code within the config class has been commented out as to not automatically generate it within the config file.

This isn't my best code, but I believe it is quite readable and works well enough to release. I've done thorough testing, but feel free to do more.