### PR TITLE
Overclaim prevention and listing dimensions

### DIFF
--- a/src/main/java/io/icker/factions/command/ClaimCommand.java
+++ b/src/main/java/io/icker/factions/command/ClaimCommand.java
@@ -16,6 +16,8 @@ import net.minecraft.util.Formatting;
 import net.minecraft.util.math.ChunkPos;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 public class ClaimCommand {
@@ -33,11 +35,29 @@ public class ClaimCommand {
 
 		if (count == 0) return 1;
 
-		String claimText = claims.stream() // TODO: show dimension
-			.map(claim -> String.format("(%d, %d)", claim.x, claim.z))
-			.collect(Collectors.joining(", "));
+		HashMap<String, ArrayList<Claim>> claimsMap = new HashMap<String, ArrayList<Claim>>();
 
-		new Message(claimText).format(Formatting.ITALIC).send(source.getPlayer(), false);
+		claims.forEach(claim -> {
+			claimsMap.putIfAbsent(claim.level, new ArrayList<Claim>());
+			claimsMap.get(claim.level).add(claim);
+		});
+
+		Message claimText = new Message("");
+		claimsMap.forEach((level, array) -> {
+			level = Pattern.compile("_([a-z])")
+					.matcher(level.split(":", 2)[1])
+					.replaceAll(m -> " " + m.group(1).toUpperCase());
+			level = level.substring(0, 1).toUpperCase() +
+					level.substring(1);
+			claimText.add("\n");
+			claimText.add(new Message(level).format(Formatting.GRAY));
+			claimText.filler("»");
+			claimText.add(array.stream()
+				.map(claim -> String.format("(%d,%d)", claim.x, claim.z))
+				.collect(Collectors.joining(", ")));
+		});
+
+		claimText.format(Formatting.ITALIC).send(source.getPlayer(), false);
 		return 1;
 	}
 

--- a/src/main/java/io/icker/factions/command/ClaimCommand.java
+++ b/src/main/java/io/icker/factions/command/ClaimCommand.java
@@ -2,6 +2,8 @@ package io.icker.factions.command;
 
 import com.mojang.brigadier.context.CommandContext;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+import io.icker.factions.config.Config;
 import io.icker.factions.database.Claim;
 import io.icker.factions.database.Faction;
 import io.icker.factions.database.Member;
@@ -60,6 +62,21 @@ public class ClaimCommand {
 		
 		String owner = existingClaim.getFaction().name == member.getFaction().name ? "Your" : "Another";
 		new Message(owner + " faction already owns this chunk").fail().send(player, false);
+		return 0;
+	}
+
+	public static int addCheck(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+		ServerPlayerEntity player = context.getSource().getPlayer();
+		Faction faction = Member.get(player.getUuid()).getFaction();
+
+		int requiredPower = (faction.getClaims().size() + 1) * Config.CLAIM_WEIGHT;
+		int maxPower = faction.getMembers().size() * Config.MEMBER_POWER + Config.BASE_POWER;
+		
+		if (maxPower >= requiredPower) {
+			return add(context);
+		}
+		
+		new Message("Not enough faction power to claim chunk.").fail().send(player, false);
 		return 0;
 	}
 

--- a/src/main/java/io/icker/factions/command/CommandRegistry.java
+++ b/src/main/java/io/icker/factions/command/CommandRegistry.java
@@ -180,9 +180,9 @@ public class CommandRegistry {
 				.literal("accept")
 				.requires(s -> PermissionsWrapper.require(s, "factions.ally.accept"))
 				.then(
-						CommandManager.argument("faction", StringArgumentType.greedyString())
-								.suggests((ctx, builder) -> suggestMatching(FactionSuggestions.allyInvites(ctx), builder))
-								.executes(AllyCommand::accept)
+					CommandManager.argument("faction", StringArgumentType.greedyString())
+						.suggests((ctx, builder) -> suggestMatching(FactionSuggestions.allyInvites(ctx), builder))
+						.executes(AllyCommand::accept)
 				)
 				.build();
 		
@@ -196,9 +196,9 @@ public class CommandRegistry {
 				.literal("remove")
 				.requires(s -> PermissionsWrapper.require(s, "factions.ally.remove"))
 				.then(
-						CommandManager.argument("faction", StringArgumentType.greedyString())
-								.suggests((ctx, builder) -> suggestMatching(FactionSuggestions.allies(ctx), builder))
-								.executes(AllyCommand::remove)
+					CommandManager.argument("faction", StringArgumentType.greedyString())
+						.suggests((ctx, builder) -> suggestMatching(FactionSuggestions.allies(ctx), builder))
+						.executes(AllyCommand::remove)
 				)
 				.build();
 
@@ -206,6 +206,11 @@ public class CommandRegistry {
 			.literal("claim")
 			.requires(s -> PermissionsWrapper.require(s, "factions.claim"))
 			.requires(CommandRegistry::isRankAboveCivilian)
+			.build();
+
+		LiteralCommandNode<ServerCommandSource> addClaim = CommandManager
+			.literal("add")
+			.requires(s -> PermissionsWrapper.require(s, "factions.claim.add"))
 			.executes(ClaimCommand::add)
 			.build();
 
@@ -268,9 +273,9 @@ public class CommandRegistry {
 			.literal("disband")
 			.requires(s -> PermissionsWrapper.require(s, "factions.admin.disband", Config.REQUIRED_BYPASS_LEVEL))
 			.then(
-					CommandManager.argument("faction", StringArgumentType.greedyString())
-							.suggests((ctx, builder) -> suggestMatching(FactionSuggestions.all(ctx), builder))
-							.executes(AdminCommand::disband)
+				CommandManager.argument("faction", StringArgumentType.greedyString())
+					.suggests((ctx, builder) -> suggestMatching(FactionSuggestions.all(ctx), builder))
+					.executes(AdminCommand::disband)
 			)
 			.build();
 
@@ -351,6 +356,7 @@ public class CommandRegistry {
 		admin.addChild(adminDisband);
 
 		factions.addChild(claim);
+		claim.addChild(addClaim);
 		claim.addChild(listClaim);
 		claim.addChild(removeClaim);
 		removeClaim.addChild(removeAllClaims);

--- a/src/main/java/io/icker/factions/command/CommandRegistry.java
+++ b/src/main/java/io/icker/factions/command/CommandRegistry.java
@@ -320,7 +320,7 @@ public class CommandRegistry {
 			.build();
 
 		LiteralCommandNode<ServerCommandSource> zoneMsg = CommandManager
-			.literal("zonemsg")
+			.literal("zoneMsg")
 			.requires(s -> Config.ZONE_MESSAGE)
 			.requires(s -> PermissionsWrapper.require(s, "factions.zonemsg"))
 			.executes(new ZoneMsgCommand())

--- a/src/main/java/io/icker/factions/command/CommandRegistry.java
+++ b/src/main/java/io/icker/factions/command/CommandRegistry.java
@@ -211,7 +211,11 @@ public class CommandRegistry {
 		LiteralCommandNode<ServerCommandSource> addClaim = CommandManager
 			.literal("add")
 			.requires(s -> PermissionsWrapper.require(s, "factions.claim.add"))
-			.executes(ClaimCommand::add)
+			.then(
+				CommandManager.literal("force")
+					.executes(ClaimCommand::add)
+			)
+			.executes(ClaimCommand::addCheck)
 			.build();
 
 		LiteralCommandNode<ServerCommandSource> listClaim = CommandManager

--- a/src/main/java/io/icker/factions/command/InfoCommand.java
+++ b/src/main/java/io/icker/factions/command/InfoCommand.java
@@ -67,7 +67,7 @@ public class InfoCommand  {
 			.collect(Collectors.joining(", "));
 
         int requiredPower = faction.getClaims().size() * Config.CLAIM_WEIGHT;
-        int maxPower = Config.BASE_POWER + (members.size() * Config.MEMBER_POWER);
+        int maxPower = members.size() * Config.MEMBER_POWER + Config.BASE_POWER;
 
         new Message("")
             .add(


### PR DESCRIPTION
Changes:
- `/f claim` now does nothing, all functionality moved to `/f claim add`. This change was done for clarity.
- `/f claim add` requires the permission `factions.claim.add`.
- `/f claim add` will now error if you don't have enough power to claim a chunk. This can be overridden with `/f claim force`.
- `/f claim list` now displays dimensions, example below.

![`/f claim list`](https://user-images.githubusercontent.com/38594963/165968689-16201830-64f2-459e-aefe-84f98492719e.png)

Fixes #2
Fixes #11