### PR TITLE
Placeholders API Support (and preparation for the per-player patch)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ group = project.maven_group
 repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url = "https://repo.mikeprimm.com/" }
+    maven { url "https://maven.nucleoid.xyz/" }
 }
 
 loom {
@@ -26,6 +27,7 @@ dependencies {
     
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
+    modImplementation include("eu.pb4:placeholder-api:${project.papi_version}")
     include "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
     compileOnly "us.dynmap:DynmapCoreAPI:${project.dynmap_api_version}"
     implementation(include("com.h2database:h2:${project.h2_version}"))

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ h2_version=1.4.200
 fabric_version=0.55.2+1.19
 lucko_permissions_version=0.1-SNAPSHOT
 dynmap_api_version=3.4-beta-3
+papi_version=2.0.0-beta.6+1.19

--- a/src/main/java/io/icker/factions/FactionsMod.java
+++ b/src/main/java/io/icker/factions/FactionsMod.java
@@ -1,31 +1,26 @@
 package io.icker.factions;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-
 import io.icker.factions.command.*;
 import io.icker.factions.config.Config;
-import io.icker.factions.core.ChatManager;
-import io.icker.factions.core.FactionsManager;
-import io.icker.factions.core.InteractionManager;
-import io.icker.factions.core.ServerManager;
-import io.icker.factions.core.SoundManager;
-import io.icker.factions.core.WorldManager;
+import io.icker.factions.core.*;
 import io.icker.factions.util.Command;
 import io.icker.factions.util.DynmapWrapper;
 import io.icker.factions.util.Migrator;
+import io.icker.factions.util.PlaceholdersWrapper;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class FactionsMod implements ModInitializer {
     public static Logger LOGGER = LogManager.getLogger("Factions");
+    public static final String MODID = "factions";
 
     public static Config CONFIG = Config.load();
     public static DynmapWrapper dynmap;
@@ -35,6 +30,7 @@ public class FactionsMod implements ModInitializer {
         LOGGER.info("Initialized Factions Mod for Minecraft v1.19");
 
         dynmap = FabricLoader.getInstance().isModLoaded("dynmap") ? new DynmapWrapper() : null;
+        PlaceholdersWrapper.init();
         Migrator.migrate();
 
         ChatManager.register();

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -152,7 +152,7 @@ public class Faction {
     }
 
     public int adjustPower(int adjustment) {
-        int maxPower = FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
+        int maxPower = calculateMaxPower();
         int newPower = Math.min(Math.max(0, power + adjustment), maxPower);
         int oldPower = this.power;
 
@@ -246,5 +246,11 @@ public class Faction {
 
     public static void save() {
         Database.save(Faction.class, STORE.values().stream().toList());
+    }
+
+//  TODO(samu): import per-player power patch
+//  FIXME(samu): Using normal max power forumla instead of per-player max power
+    public int calculateMaxPower(){
+        return FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
     }
 }

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 @Name("Faction")
 public class Faction {
-    private static final HashMap<UUID, Faction> STORE = Database.load(Faction.class, f -> f.getID());
+    private static final HashMap<UUID, Faction> STORE = Database.load(Faction.class, Faction::getID);
 
     @Field("ID")
     private UUID id;
@@ -42,10 +42,10 @@ public class Faction {
     private SimpleInventory safe = new SimpleInventory(54);
 
     @Field("Invites")
-    public ArrayList<UUID> invites = new ArrayList<UUID>();
+    public ArrayList<UUID> invites = new ArrayList<>();
 
     @Field("Relationships")
-    private ArrayList<Relationship> relationships = new ArrayList<Relationship>();
+    private ArrayList<Relationship> relationships = new ArrayList<>();
 
     public Faction(String name, String description, String motd, Formatting color, boolean open, int power) {
         this.id = UUID.randomUUID();
@@ -57,8 +57,9 @@ public class Faction {
         this.power = power;
     }
 
-    public Faction() { ; }
+    public Faction() {}
 
+    @SuppressWarnings("unused")
     public String getKey() {
         return id.toString();
     }
@@ -83,6 +84,7 @@ public class Faction {
         return STORE.values();
     }
 
+    @SuppressWarnings("unused")
     public static List<Faction> allBut(UUID id) {
         return STORE.values()
             .stream()
@@ -118,6 +120,7 @@ public class Faction {
         return safe;
     }
 
+    @SuppressWarnings("unused")
     public void setSafe(SimpleInventory safe) {
         this.safe = safe;
     }
@@ -174,7 +177,7 @@ public class Faction {
     public void removeAllClaims() {
         Claim.getByFaction(id)
             .stream()
-            .forEach(c -> c.remove());
+            .forEach(Claim::remove);
         FactionEvents.REMOVE_ALL_CLAIMS.invoker().onRemoveAllClaims(this);
     }
 
@@ -249,7 +252,6 @@ public class Faction {
     }
 
 //  TODO(samu): import per-player power patch
-//  FIXME(samu): Using normal max power forumla instead of per-player max power
     public int calculateMaxPower(){
         return FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
     }

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -263,6 +263,6 @@ public class Faction {
 
 //  TODO(samu): import per-player power patch
     public int calculateMaxPower(){
-        return FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
+        return FactionsMod.CONFIG.POWER.BASE + (getUsers().size() * FactionsMod.CONFIG.POWER.MEMBER);
     }
 }

--- a/src/main/java/io/icker/factions/api/persistents/User.java
+++ b/src/main/java/io/icker/factions/api/persistents/User.java
@@ -1,15 +1,16 @@
 package io.icker.factions.api.persistents;
 
+import io.icker.factions.FactionsMod;
+import io.icker.factions.api.events.FactionEvents;
+import io.icker.factions.database.Database;
+import io.icker.factions.database.Field;
+import io.icker.factions.database.Name;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import io.icker.factions.api.events.FactionEvents;
-import io.icker.factions.database.Database;
-import io.icker.factions.database.Field;
-import io.icker.factions.database.Name;
 
 @Name("User")
 public class User {
@@ -63,7 +64,9 @@ public class User {
         this.id = id;
     }
 
-    public User() { ; }
+    public User() {
+        ;
+    }
 
     public String getKey() {
         return id.toString();
@@ -78,9 +81,9 @@ public class User {
 
     public static List<User> getByFaction(UUID factionID) {
         return STORE.values()
-            .stream()
-            .filter(m -> m.isInFaction() && m.factionID.equals(factionID))
-            .toList();
+                .stream()
+                .filter(m -> m.isInFaction() && m.factionID.equals(factionID))
+                .toList();
     }
 
     public static void add(User user) {
@@ -97,11 +100,11 @@ public class User {
 
     private String getEnumName(Enum<?> value) {
         return Arrays
-            .stream(value.name().split("_"))
-            .map(word -> word.isEmpty() ? word :
-                Character.toTitleCase(word.charAt(0)) +
-                word.substring(1).toLowerCase())
-            .collect(Collectors.joining(" "));
+                .stream(value.name().split("_"))
+                .map(word -> word.isEmpty() ? word :
+                        Character.toTitleCase(word.charAt(0)) +
+                        word.substring(1).toLowerCase())
+                .collect(Collectors.joining(" "));
     }
 
     public String getRankName() {
@@ -144,4 +147,22 @@ public class User {
     public static void save() {
         Database.save(User.class, STORE.values().stream().toList());
     }
+
+//  TODO(samu): import per-player power patch
+//  FIXME(samu): Using config member power instead of per-player max power
+//region user power
+    public static int getMaxPower(UUID userUUID) {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+    public int getMaxPower() {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+
+    public static int getPower(UUID userUUID) {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+    public int getPower() {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+//endregion
 }

--- a/src/main/java/io/icker/factions/api/persistents/User.java
+++ b/src/main/java/io/icker/factions/api/persistents/User.java
@@ -1,6 +1,5 @@
 package io.icker.factions.api.persistents;
 
-import io.icker.factions.FactionsMod;
 import io.icker.factions.api.events.FactionEvents;
 import io.icker.factions.database.Database;
 import io.icker.factions.database.Field;
@@ -14,7 +13,7 @@ import java.util.stream.Collectors;
 
 @Name("User")
 public class User {
-    private static final HashMap<UUID, User> STORE = Database.load(User.class, p -> p.getID());
+    private static final HashMap<UUID, User> STORE = Database.load(User.class, User::getID);
 
     public enum ChatMode {
         FOCUS,
@@ -64,10 +63,9 @@ public class User {
         this.id = id;
     }
 
-    public User() {
-        ;
-    }
+    public User() {}
 
+    @SuppressWarnings("unused")
     public String getKey() {
         return id.toString();
     }
@@ -148,21 +146,4 @@ public class User {
         Database.save(User.class, STORE.values().stream().toList());
     }
 
-//  TODO(samu): import per-player power patch
-//  FIXME(samu): Using config member power instead of per-player max power
-//region user power
-    public static int getMaxPower(UUID userUUID) {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-    public int getMaxPower() {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-
-    public static int getPower(UUID userUUID) {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-    public int getPower() {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-//endregion
 }

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -1,0 +1,208 @@
+package io.icker.factions.util;
+
+import io.icker.factions.FactionsMod;
+import io.icker.factions.api.persistents.User;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.text.TextColor;
+import net.minecraft.util.Identifier;
+
+import static eu.pb4.placeholders.api.PlaceholderResult.invalid;
+import static eu.pb4.placeholders.api.PlaceholderResult.value;
+import static eu.pb4.placeholders.api.Placeholders.register;
+import static io.icker.factions.FactionsMod.MODID;
+import static java.lang.Integer.*;
+import static net.minecraft.util.Formatting.DARK_GRAY;
+
+public class PlaceholdersWrapper {
+    public static final Identifier FACTION_NAME_ID = new Identifier(MODID, "name");
+    public static final Identifier FACTION_DESCRIPTION_ID = new Identifier(MODID, "description");
+    public static final Identifier FACTION_STATE_ID = new Identifier(MODID, "state");
+    public static final Identifier FACTION_POWER_ID = new Identifier(MODID, "power");
+    public static final Identifier FACTION_POWER_FORMATTED_ID = new Identifier(MODID, "power_formatted");
+    public static final Identifier FACTION_MAX_POWER_ID = new Identifier(MODID, "max_power");
+    public static final Identifier FACTION_PLAYER_POWER_ID = new Identifier(MODID, "player_power");
+    public static final Identifier FACTION_PLAYER_MAX_POWER_ID = new Identifier(MODID, "player_max_power");
+    public static final Identifier FACTION_REQUIRED_POWER_ID = new Identifier(MODID, "required_power");
+    public static final Identifier FACTION_REQUIRED_POWER_FORMATTED_ID = new Identifier(MODID, "required_power_formatted");
+    public static final String NULL_STRING = "N/A";
+    public static final Text NULL_TEXT = Text.literal(NULL_STRING).formatted(DARK_GRAY);
+
+    public static void init() {
+        register(FACTION_NAME_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            Text r = NULL_TEXT;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = Text.literal(faction.getName()).formatted(member.getFaction().getColor());
+
+            return value(r);
+        });
+
+        register(FACTION_DESCRIPTION_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = faction.getDescription();
+
+            return value(r);
+        });
+
+        register(FACTION_STATE_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = "" + faction.isOpen();
+
+            return value(r);
+        });
+
+        register(FACTION_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = "" + faction.getPower();
+
+            return value(r);
+        });
+
+        register(FACTION_POWER_FORMATTED_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            Text r = NULL_TEXT;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null) {
+//              TODO(samu): import per-player power patch
+//              FIXME(samu): Using normal max power formula instead of per-player max power
+                final int red = mapBoundRange(faction.calculateMaxPower(), 0, 170, 255, faction.getPower());
+                final int green = mapBoundRange(0, faction.calculateMaxPower(), 170, 255, faction.getPower());
+                r = Text.literal("" + faction.getPower()).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + toHexString(green) + "AA")));
+            }
+
+            return value(r);
+        });
+
+        register(FACTION_MAX_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+//          TODO(samu): import per-player power patch
+//          FIXME(samu): Using normal max power formula instead of per-player max power
+            if (faction != null) r = "" + faction.calculateMaxPower();
+
+            return value(r);
+        });
+
+        register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value("" + User.getPower(ctx.player().getUuid()));
+
+            String r = "" + member.getPower();
+
+            return value(r);
+        });
+
+        register(FACTION_PLAYER_MAX_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value("" + User.getMaxPower(ctx.player().getUuid()));
+
+            String r = "" + member.getMaxPower();
+
+            return value(r);
+        });
+
+        register(FACTION_REQUIRED_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = "" + faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+
+            return value(r);
+        });
+
+        register(FACTION_REQUIRED_POWER_FORMATTED_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            Text r = NULL_TEXT;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+
+            if (faction != null) {
+                final int reqPower = faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+                final int red = mapBoundRange(0, faction.getPower(), 85, 255, reqPower);
+                r = Text.literal("" + reqPower).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + "5555")));
+            }
+
+            return value(r);
+        });
+    }
+
+    @SuppressWarnings("all")
+    private static int mapBoundRange(int a1, int a2, int b1, int b2, int s) {
+        return min(b2, max(b1, b1 + ((s - a1) * (b2 - b1)) / (a2 - a1)));
+    }
+}

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -22,7 +22,6 @@ public class PlaceholdersWrapper {
     public static final Identifier FACTION_POWER_FORMATTED_ID = new Identifier(MODID, "power_formatted");
     public static final Identifier FACTION_MAX_POWER_ID = new Identifier(MODID, "max_power");
     public static final Identifier FACTION_PLAYER_POWER_ID = new Identifier(MODID, "player_power");
-    public static final Identifier FACTION_PLAYER_MAX_POWER_ID = new Identifier(MODID, "player_max_power");
     public static final Identifier FACTION_REQUIRED_POWER_ID = new Identifier(MODID, "required_power");
     public static final Identifier FACTION_REQUIRED_POWER_FORMATTED_ID = new Identifier(MODID, "required_power_formatted");
     public static final String NULL_STRING = "N/A";
@@ -110,8 +109,6 @@ public class PlaceholdersWrapper {
             final var faction = member.getFaction();
 
             if (faction != null) {
-//              TODO(samu): import per-player power patch
-//              FIXME(samu): Using normal max power formula instead of per-player max power
                 final int red = mapBoundRange(faction.calculateMaxPower(), 0, 170, 255, faction.getPower());
                 final int green = mapBoundRange(0, faction.calculateMaxPower(), 170, 255, faction.getPower());
                 r = Text.literal("" + faction.getPower()).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + toHexString(green) + "AA")));
@@ -131,34 +128,13 @@ public class PlaceholdersWrapper {
 
             final var faction = member.getFaction();
 
-//          TODO(samu): import per-player power patch
-//          FIXME(samu): Using normal max power formula instead of per-player max power
             if (faction != null) r = "" + faction.calculateMaxPower();
 
             return value(r);
         });
 
         register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
-            if (!ctx.hasPlayer()) return invalid("No Player!");
-            assert ctx.player() != null;
-
-            final var member = User.get(ctx.player().getUuid());
-            if (member == null) return value("" + User.getPower(ctx.player().getUuid()));
-
-            String r = "" + member.getPower();
-
-            return value(r);
-        });
-
-        register(FACTION_PLAYER_MAX_POWER_ID, (ctx, argument) -> {
-            if (!ctx.hasPlayer()) return invalid("No Player!");
-            assert ctx.player() != null;
-
-            final var member = User.get(ctx.player().getUuid());
-            if (member == null) return value("" + User.getMaxPower(ctx.player().getUuid()));
-
-            String r = "" + member.getMaxPower();
-
+            String r = "" + FactionsMod.CONFIG.MEMBER_POWER;
             return value(r);
         });
 

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -134,7 +134,7 @@ public class PlaceholdersWrapper {
         });
 
         register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
-            String r = "" + FactionsMod.CONFIG.MEMBER_POWER;
+            String r = "" + FactionsMod.CONFIG.POWER.MEMBER;
             return value(r);
         });
 
@@ -150,7 +150,7 @@ public class PlaceholdersWrapper {
             final var faction = member.getFaction();
 
             if (faction != null)
-                r = "" + faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+                r = "" + faction.getClaims().size() * FactionsMod.CONFIG.POWER.CLAIM_WEIGHT;
 
             return value(r);
         });
@@ -168,7 +168,7 @@ public class PlaceholdersWrapper {
 
 
             if (faction != null) {
-                final int reqPower = faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+                final int reqPower = faction.getClaims().size() * FactionsMod.CONFIG.POWER.CLAIM_WEIGHT;
                 final int red = mapBoundRange(0, faction.getPower(), 85, 255, reqPower);
                 r = Text.literal("" + reqPower).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + "5555")));
             }


### PR DESCRIPTION
This PR adds support for [Patbox/TextPlaceholderAPI](https://github.com/Patbox/TextPlaceholderAPI) and adds 5 methods that will be used for a (still W.I.P.) per-player power and permission-based power patch.
If you don't want them I can just refactor the code and add back everything once the other patch is ready.

![image](https://user-images.githubusercontent.com/32773961/177006518-725456ab-5d85-4d82-bfc6-19cef7a21ba0.png)

Placeholders added:
- %factions:name%
- %factions:description%
- %factions:state%
- %factions:power%
- %factions:power_formatted%
- %factions:max_power%
- %factions:player_power%
- %factions:player_max_power%
- %factions:required_power%
- %factions:required_power_formatted%

I'm also starting to work on a fork of this mod over at [CampHQmc/factions](https://github.com/CampHQmc/factions) where I will introduce more breaking and radical changes.