### PR TITLE
WIP: Per player power patch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ group = project.maven_group
 repositories {
     maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
     maven { url = "https://repo.mikeprimm.com/" }
+    maven { url "https://maven.nucleoid.xyz/" }
 }
 
 loom {
@@ -26,6 +27,7 @@ dependencies {
     
     modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
     modImplementation "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
+    modImplementation include("eu.pb4:placeholder-api:${project.papi_version}")
     include "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
     compileOnly "us.dynmap:DynmapCoreAPI:${project.dynmap_api_version}"
     implementation(include("com.h2database:h2:${project.h2_version}"))

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     modImplementation "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
     modImplementation include("eu.pb4:placeholder-api:${project.papi_version}")
     include "me.lucko:fabric-permissions-api:${project.lucko_permissions_version}"
+    compileOnly "net.luckperms:api:${project.lpapi_version}"
     compileOnly "us.dynmap:DynmapCoreAPI:${project.dynmap_api_version}"
     implementation(include("com.h2database:h2:${project.h2_version}"))
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,3 +15,4 @@ h2_version=1.4.200
 fabric_version=0.55.2+1.19
 lucko_permissions_version=0.1-SNAPSHOT
 dynmap_api_version=3.4-beta-3
+papi_version=2.0.0-beta.6+1.19

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,5 +14,6 @@ archives_base_name = factions
 h2_version=1.4.200
 fabric_version=0.55.2+1.19
 lucko_permissions_version=0.1-SNAPSHOT
+lpapi_version = 5.4
 dynmap_api_version=3.4-beta-3
 papi_version=2.0.0-beta.6+1.19

--- a/src/main/java/io/icker/factions/FactionsMod.java
+++ b/src/main/java/io/icker/factions/FactionsMod.java
@@ -1,31 +1,26 @@
 package io.icker.factions;
 
-import org.apache.logging.log4j.LogManager;
-import org.apache.logging.log4j.Logger;
-
 import com.mojang.brigadier.CommandDispatcher;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-
 import io.icker.factions.command.*;
 import io.icker.factions.config.Config;
-import io.icker.factions.core.ChatManager;
-import io.icker.factions.core.FactionsManager;
-import io.icker.factions.core.InteractionManager;
-import io.icker.factions.core.ServerManager;
-import io.icker.factions.core.SoundManager;
-import io.icker.factions.core.WorldManager;
+import io.icker.factions.core.*;
 import io.icker.factions.util.Command;
 import io.icker.factions.util.DynmapWrapper;
 import io.icker.factions.util.Migrator;
+import io.icker.factions.util.PlaceholdersWrapper;
 import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v2.CommandRegistrationCallback;
 import net.fabricmc.loader.api.FabricLoader;
 import net.minecraft.command.CommandRegistryAccess;
 import net.minecraft.server.command.CommandManager;
 import net.minecraft.server.command.ServerCommandSource;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 
 public class FactionsMod implements ModInitializer {
     public static Logger LOGGER = LogManager.getLogger("Factions");
+    public static final String MODID = "factions";
 
     public static Config CONFIG = Config.load();
     public static DynmapWrapper dynmap;
@@ -35,6 +30,7 @@ public class FactionsMod implements ModInitializer {
         LOGGER.info("Initialized Factions Mod for Minecraft v1.19");
 
         dynmap = FabricLoader.getInstance().isModLoaded("dynmap") ? new DynmapWrapper() : null;
+        PlaceholdersWrapper.init();
         Migrator.migrate();
 
         ChatManager.register();

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -152,7 +152,7 @@ public class Faction {
     }
 
     public int adjustPower(int adjustment) {
-        int maxPower = FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
+        int maxPower = calculateMaxPower();
         int newPower = Math.min(Math.max(0, power + adjustment), maxPower);
         int oldPower = this.power;
 
@@ -246,5 +246,11 @@ public class Faction {
 
     public static void save() {
         Database.save(Faction.class, STORE.values().stream().toList());
+    }
+
+//  TODO(samu): import per-player power patch
+//  FIXME(samu): Using normal max power forumla instead of per-player max power
+    public int calculateMaxPower(){
+        return FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
     }
 }

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -1,6 +1,5 @@
 package io.icker.factions.api.persistents;
 
-import io.icker.factions.FactionsMod;
 import io.icker.factions.api.events.FactionEvents;
 import io.icker.factions.database.Database;
 import io.icker.factions.database.Field;
@@ -10,6 +9,8 @@ import net.minecraft.inventory.SimpleInventory;
 import net.minecraft.util.Formatting;
 
 import java.util.*;
+
+import static io.icker.factions.FactionsMod.CONFIG;
 
 @Name("Faction")
 public class Faction {
@@ -102,8 +103,8 @@ public class Faction {
     }
 
     public Message getTruncatedName() {
-        boolean overLength = FactionsMod.CONFIG.NAME_MAX_LENGTH > -1 && name.length() > FactionsMod.CONFIG.NAME_MAX_LENGTH;
-        Message displayName = new Message(overLength ? name.substring(0, FactionsMod.CONFIG.NAME_MAX_LENGTH - 1) + "..." : name);
+        boolean overLength = CONFIG.NAME_MAX_LENGTH > -1 && name.length() > CONFIG.NAME_MAX_LENGTH;
+        Message displayName = new Message(overLength ? name.substring(0, CONFIG.NAME_MAX_LENGTH - 1) + "..." : name);
         if (overLength) {
             displayName = displayName.hover(name);
         }
@@ -165,8 +166,7 @@ public class Faction {
     }
 
     public int adjustPower(int adjustment) {
-        int maxPower = calculateMaxPower();
-        int newPower = Math.min(Math.max(0, power + adjustment), maxPower);
+        int newPower = Math.min(Math.max(0, power + adjustment), calculateMaxPower());
         int oldPower = this.power;
 
         if (newPower == oldPower) return 0;
@@ -184,6 +184,7 @@ public class Faction {
         return Claim.getByFaction(id);
     }
 
+    @SuppressWarnings("all")
     public void removeAllClaims() {
         Claim.getByFaction(id)
             .stream()
@@ -261,8 +262,11 @@ public class Faction {
         Database.save(Faction.class, STORE.values().stream().toList());
     }
 
-//  TODO(samu): import per-player power patch
     public int calculateMaxPower(){
-        return FactionsMod.CONFIG.POWER.BASE + (getUsers().size() * FactionsMod.CONFIG.POWER.MEMBER);
+        int maxPower = CONFIG.POWER.BASE; // + (faction.getMembers().size() * Config.MEMBER_POWER);
+        for (final User user : getUsers()) {
+            maxPower += user.getMaxPower();
+        }
+        return maxPower;
     }
 }

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -12,7 +12,7 @@ import java.util.*;
 
 @Name("Faction")
 public class Faction {
-    private static final HashMap<UUID, Faction> STORE = Database.load(Faction.class, f -> f.getID());
+    private static final HashMap<UUID, Faction> STORE = Database.load(Faction.class, Faction::getID);
 
     @Field("ID")
     private UUID id;
@@ -42,10 +42,10 @@ public class Faction {
     private SimpleInventory safe = new SimpleInventory(54);
 
     @Field("Invites")
-    public ArrayList<UUID> invites = new ArrayList<UUID>();
+    public ArrayList<UUID> invites = new ArrayList<>();
 
     @Field("Relationships")
-    private ArrayList<Relationship> relationships = new ArrayList<Relationship>();
+    private ArrayList<Relationship> relationships = new ArrayList<>();
 
     public Faction(String name, String description, String motd, Formatting color, boolean open, int power) {
         this.id = UUID.randomUUID();
@@ -57,8 +57,9 @@ public class Faction {
         this.power = power;
     }
 
-    public Faction() { ; }
+    public Faction() {}
 
+    @SuppressWarnings("unused")
     public String getKey() {
         return id.toString();
     }
@@ -83,6 +84,7 @@ public class Faction {
         return STORE.values();
     }
 
+    @SuppressWarnings("unused")
     public static List<Faction> allBut(UUID id) {
         return STORE.values()
             .stream()
@@ -118,6 +120,7 @@ public class Faction {
         return safe;
     }
 
+    @SuppressWarnings("unused")
     public void setSafe(SimpleInventory safe) {
         this.safe = safe;
     }
@@ -174,7 +177,7 @@ public class Faction {
     public void removeAllClaims() {
         Claim.getByFaction(id)
             .stream()
-            .forEach(c -> c.remove());
+            .forEach(Claim::remove);
         FactionEvents.REMOVE_ALL_CLAIMS.invoker().onRemoveAllClaims(this);
     }
 
@@ -249,7 +252,6 @@ public class Faction {
     }
 
 //  TODO(samu): import per-player power patch
-//  FIXME(samu): Using normal max power forumla instead of per-player max power
     public int calculateMaxPower(){
         return FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
     }

--- a/src/main/java/io/icker/factions/api/persistents/Faction.java
+++ b/src/main/java/io/icker/factions/api/persistents/Faction.java
@@ -263,6 +263,6 @@ public class Faction {
 
 //  TODO(samu): import per-player power patch
     public int calculateMaxPower(){
-        return FactionsMod.CONFIG.BASE_POWER + (getUsers().size() * FactionsMod.CONFIG.MEMBER_POWER);
+        return FactionsMod.CONFIG.POWER.BASE + (getUsers().size() * FactionsMod.CONFIG.POWER.MEMBER);
     }
 }

--- a/src/main/java/io/icker/factions/api/persistents/User.java
+++ b/src/main/java/io/icker/factions/api/persistents/User.java
@@ -1,15 +1,16 @@
 package io.icker.factions.api.persistents;
 
+import io.icker.factions.FactionsMod;
+import io.icker.factions.api.events.FactionEvents;
+import io.icker.factions.database.Database;
+import io.icker.factions.database.Field;
+import io.icker.factions.database.Name;
+
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
-
-import io.icker.factions.api.events.FactionEvents;
-import io.icker.factions.database.Database;
-import io.icker.factions.database.Field;
-import io.icker.factions.database.Name;
 
 @Name("User")
 public class User {
@@ -63,7 +64,9 @@ public class User {
         this.id = id;
     }
 
-    public User() { ; }
+    public User() {
+        ;
+    }
 
     public String getKey() {
         return id.toString();
@@ -78,9 +81,9 @@ public class User {
 
     public static List<User> getByFaction(UUID factionID) {
         return STORE.values()
-            .stream()
-            .filter(m -> m.isInFaction() && m.factionID.equals(factionID))
-            .toList();
+                .stream()
+                .filter(m -> m.isInFaction() && m.factionID.equals(factionID))
+                .toList();
     }
 
     public static void add(User user) {
@@ -97,11 +100,11 @@ public class User {
 
     private String getEnumName(Enum<?> value) {
         return Arrays
-            .stream(value.name().split("_"))
-            .map(word -> word.isEmpty() ? word :
-                Character.toTitleCase(word.charAt(0)) +
-                word.substring(1).toLowerCase())
-            .collect(Collectors.joining(" "));
+                .stream(value.name().split("_"))
+                .map(word -> word.isEmpty() ? word :
+                        Character.toTitleCase(word.charAt(0)) +
+                        word.substring(1).toLowerCase())
+                .collect(Collectors.joining(" "));
     }
 
     public String getRankName() {
@@ -144,4 +147,22 @@ public class User {
     public static void save() {
         Database.save(User.class, STORE.values().stream().toList());
     }
+
+//  TODO(samu): import per-player power patch
+//  FIXME(samu): Using config member power instead of per-player max power
+//region user power
+    public static int getMaxPower(UUID userUUID) {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+    public int getMaxPower() {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+
+    public static int getPower(UUID userUUID) {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+    public int getPower() {
+        return FactionsMod.CONFIG.MEMBER_POWER;
+    }
+//endregion
 }

--- a/src/main/java/io/icker/factions/api/persistents/User.java
+++ b/src/main/java/io/icker/factions/api/persistents/User.java
@@ -1,6 +1,5 @@
 package io.icker.factions.api.persistents;
 
-import io.icker.factions.FactionsMod;
 import io.icker.factions.api.events.FactionEvents;
 import io.icker.factions.database.Database;
 import io.icker.factions.database.Field;
@@ -14,7 +13,7 @@ import java.util.stream.Collectors;
 
 @Name("User")
 public class User {
-    private static final HashMap<UUID, User> STORE = Database.load(User.class, p -> p.getID());
+    private static final HashMap<UUID, User> STORE = Database.load(User.class, User::getID);
 
     public enum ChatMode {
         FOCUS,
@@ -64,10 +63,9 @@ public class User {
         this.id = id;
     }
 
-    public User() {
-        ;
-    }
+    public User() {}
 
+    @SuppressWarnings("unused")
     public String getKey() {
         return id.toString();
     }
@@ -148,21 +146,4 @@ public class User {
         Database.save(User.class, STORE.values().stream().toList());
     }
 
-//  TODO(samu): import per-player power patch
-//  FIXME(samu): Using config member power instead of per-player max power
-//region user power
-    public static int getMaxPower(UUID userUUID) {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-    public int getMaxPower() {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-
-    public static int getPower(UUID userUUID) {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-    public int getPower() {
-        return FactionsMod.CONFIG.MEMBER_POWER;
-    }
-//endregion
 }

--- a/src/main/java/io/icker/factions/api/persistents/User.java
+++ b/src/main/java/io/icker/factions/api/persistents/User.java
@@ -4,12 +4,16 @@ import io.icker.factions.api.events.FactionEvents;
 import io.icker.factions.database.Database;
 import io.icker.factions.database.Field;
 import io.icker.factions.database.Name;
+import org.jetbrains.annotations.NotNull;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.UUID;
 import java.util.stream.Collectors;
+
+import static io.icker.factions.FactionsMod.CONFIG;
+import static io.icker.factions.util.PermissionUtil.getPermissionPower;
 
 @Name("User")
 public class User {
@@ -44,6 +48,9 @@ public class User {
     @Field("Rank")
     public Rank rank;
 
+//    @Field("Power")
+//    private int power = CONFIG.POWER.MEMBER + getPermissionPower(getID());
+
     @Field("Radar")
     public boolean radar = false;
 
@@ -63,7 +70,8 @@ public class User {
         this.id = id;
     }
 
-    public User() {}
+//    NOTE(CamperSamu): why does this exist??
+//    public User() {}
 
     @SuppressWarnings("unused")
     public String getKey() {
@@ -146,4 +154,40 @@ public class User {
         Database.save(User.class, STORE.values().stream().toList());
     }
 
+    //region Power Management
+    public static int getMaxPower(final @NotNull UUID userUUID) {
+        final var user = get(userUUID);
+        return user != null ? user.getMaxPower() : 0;
+    }
+
+    public int getMaxPower() {
+        return CONFIG.POWER.MEMBER + getPermissionPower(getID());
+    }
+
+//    public static int getPower(final @NotNull UUID userUUID) {
+//        return get(userUUID).getPower();
+//    }
+
+//    public int getPower() {
+//        return power;
+//    }
+
+//    @SuppressWarnings("unused")
+//    public static void setPower(final @NotNull UUID userUUID, final int newPower) {
+//        get(userUUID).setPower(newPower);
+//    }
+
+//    public void setPower(final int newPower) {
+//        power = newPower;
+//    }
+
+//    @SuppressWarnings("unused")
+//    public static void addPower(final @NotNull UUID userUUID, final int powerModifier) {
+//        get(userUUID).addPower(powerModifier);
+//    }
+
+//    public void addPower(final int powerModifier) {
+//        power += powerModifier;
+//    }
+    //endregion
 }

--- a/src/main/java/io/icker/factions/command/SettingsCommand.java
+++ b/src/main/java/io/icker/factions/command/SettingsCommand.java
@@ -1,9 +1,7 @@
 package io.icker.factions.command;
 
 import com.mojang.brigadier.context.CommandContext;
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.tree.LiteralCommandNode;
-
 import io.icker.factions.api.persistents.User;
 import io.icker.factions.util.Command;
 import io.icker.factions.util.Message;
@@ -12,8 +10,10 @@ import net.minecraft.server.command.ServerCommandSource;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Formatting;
 
+import static io.icker.factions.util.Command.Requires.hasPerms;
+
 public class SettingsCommand implements Command{
-    private int setChat(CommandContext<ServerCommandSource> context, User.ChatMode option) throws CommandSyntaxException {
+    private int setChat(CommandContext<ServerCommandSource> context, User.ChatMode option) {
         ServerPlayerEntity player = context.getSource().getPlayer();
         User user = User.get(player.getUuid());
         user.chat = option;   
@@ -45,7 +45,7 @@ public class SettingsCommand implements Command{
         return 1;
     }
 
-    private int radar(CommandContext<ServerCommandSource> context) throws CommandSyntaxException {
+    private int radar(CommandContext<ServerCommandSource> context) {
         ServerCommandSource source = context.getSource();
         ServerPlayerEntity player = source.getPlayer();
 
@@ -67,22 +67,22 @@ public class SettingsCommand implements Command{
     public LiteralCommandNode<ServerCommandSource> getNode() {
         return CommandManager
             .literal("settings")
-            .requires(Requires.hasPerms("factions.settings", 0))
+            .requires(hasPerms("factions.settings", 0))
             .then(
                 CommandManager.literal("chat")
-                .requires(Requires.hasPerms("factions.settings.chat", 0))
+                .requires(hasPerms("factions.settings.chat", 0))
                 .then(CommandManager.literal("global").executes(context -> setChat(context, User.ChatMode.GLOBAL)))
                 .then(CommandManager.literal("faction").executes(context -> setChat(context, User.ChatMode.FACTION)))
                 .then(CommandManager.literal("focus").executes(context -> setChat(context, User.ChatMode.FOCUS)))
             )
             .then(
                 CommandManager.literal("radar")
-                .requires(Requires.hasPerms("factions.settings.radar", 0))
+                .requires(hasPerms("factions.settings.radar", 0))
                 .executes(this::radar)
             )
             .then(
                 CommandManager.literal("sounds")
-                .requires(Requires.hasPerms("factions.settings.sounds", 0))
+                .requires(hasPerms("factions.settings.sounds", 0))
                 .then(CommandManager.literal("none").executes(context -> setSounds(context, User.SoundMode.NONE)))
                 .then(CommandManager.literal("warnings").executes(context -> setSounds(context, User.SoundMode.WARNINGS)))
                 .then(CommandManager.literal("faction").executes(context -> setSounds(context, User.SoundMode.FACTION)))

--- a/src/main/java/io/icker/factions/util/PermissionUtil.java
+++ b/src/main/java/io/icker/factions/util/PermissionUtil.java
@@ -1,0 +1,37 @@
+package io.icker.factions.util;
+
+import net.luckperms.api.LuckPermsProvider;
+import net.luckperms.api.model.group.Group;
+import net.luckperms.api.node.Node;
+import net.luckperms.api.query.QueryOptions;
+
+import java.util.UUID;
+
+public abstract class PermissionUtil {
+    public static int getPermissionPower(UUID uuid){
+        int power = 0;
+        try {
+
+            var user = LuckPermsProvider.get().getUserManager().getUser(uuid);
+            if (user == null) return 0;
+            for (Group inheritedGroup : user.getInheritedGroups(QueryOptions.nonContextual())) {
+                for (Node node : inheritedGroup.getNodes()) {
+                    var perm = node.getKey();
+                    if (perm.contains("factions.power.modifier.")) {
+                        int value = getNumberFromPermission(node.getKey());
+                        power+=value;
+                    }
+                }
+            }
+        } catch (Exception ignored) {}
+        return power;
+    }
+
+    public static int getNumberFromPermission(String permission) {
+        try {
+            return Integer.parseInt(permission.substring(permission.lastIndexOf(".")+1));
+        } catch (Exception ignored) {
+            return 0;
+        }
+    }
+}

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -1,0 +1,208 @@
+package io.icker.factions.util;
+
+import io.icker.factions.FactionsMod;
+import io.icker.factions.api.persistents.User;
+import net.minecraft.text.Style;
+import net.minecraft.text.Text;
+import net.minecraft.text.TextColor;
+import net.minecraft.util.Identifier;
+
+import static eu.pb4.placeholders.api.PlaceholderResult.invalid;
+import static eu.pb4.placeholders.api.PlaceholderResult.value;
+import static eu.pb4.placeholders.api.Placeholders.register;
+import static io.icker.factions.FactionsMod.MODID;
+import static java.lang.Integer.*;
+import static net.minecraft.util.Formatting.DARK_GRAY;
+
+public class PlaceholdersWrapper {
+    public static final Identifier FACTION_NAME_ID = new Identifier(MODID, "name");
+    public static final Identifier FACTION_DESCRIPTION_ID = new Identifier(MODID, "description");
+    public static final Identifier FACTION_STATE_ID = new Identifier(MODID, "state");
+    public static final Identifier FACTION_POWER_ID = new Identifier(MODID, "power");
+    public static final Identifier FACTION_POWER_FORMATTED_ID = new Identifier(MODID, "power_formatted");
+    public static final Identifier FACTION_MAX_POWER_ID = new Identifier(MODID, "max_power");
+    public static final Identifier FACTION_PLAYER_POWER_ID = new Identifier(MODID, "player_power");
+    public static final Identifier FACTION_PLAYER_MAX_POWER_ID = new Identifier(MODID, "player_max_power");
+    public static final Identifier FACTION_REQUIRED_POWER_ID = new Identifier(MODID, "required_power");
+    public static final Identifier FACTION_REQUIRED_POWER_FORMATTED_ID = new Identifier(MODID, "required_power_formatted");
+    public static final String NULL_STRING = "N/A";
+    public static final Text NULL_TEXT = Text.literal(NULL_STRING).formatted(DARK_GRAY);
+
+    public static void init() {
+        register(FACTION_NAME_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            Text r = NULL_TEXT;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = Text.literal(faction.getName()).formatted(member.getFaction().getColor());
+
+            return value(r);
+        });
+
+        register(FACTION_DESCRIPTION_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = faction.getDescription();
+
+            return value(r);
+        });
+
+        register(FACTION_STATE_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = "" + faction.isOpen();
+
+            return value(r);
+        });
+
+        register(FACTION_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = "" + faction.getPower();
+
+            return value(r);
+        });
+
+        register(FACTION_POWER_FORMATTED_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            Text r = NULL_TEXT;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null) {
+//              TODO(samu): import per-player power patch
+//              FIXME(samu): Using normal max power formula instead of per-player max power
+                final int red = mapBoundRange(faction.calculateMaxPower(), 0, 170, 255, faction.getPower());
+                final int green = mapBoundRange(0, faction.calculateMaxPower(), 170, 255, faction.getPower());
+                r = Text.literal("" + faction.getPower()).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + toHexString(green) + "AA")));
+            }
+
+            return value(r);
+        });
+
+        register(FACTION_MAX_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+//          TODO(samu): import per-player power patch
+//          FIXME(samu): Using normal max power formula instead of per-player max power
+            if (faction != null) r = "" + faction.calculateMaxPower();
+
+            return value(r);
+        });
+
+        register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value("" + User.getPower(ctx.player().getUuid()));
+
+            String r = "" + member.getPower();
+
+            return value(r);
+        });
+
+        register(FACTION_PLAYER_MAX_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value("" + User.getMaxPower(ctx.player().getUuid()));
+
+            String r = "" + member.getMaxPower();
+
+            return value(r);
+        });
+
+        register(FACTION_REQUIRED_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            String r = NULL_STRING;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+            if (faction != null)
+                r = "" + faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+
+            return value(r);
+        });
+
+        register(FACTION_REQUIRED_POWER_FORMATTED_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            Text r = NULL_TEXT;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value(r);
+
+            final var faction = member.getFaction();
+
+
+            if (faction != null) {
+                final int reqPower = faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+                final int red = mapBoundRange(0, faction.getPower(), 85, 255, reqPower);
+                r = Text.literal("" + reqPower).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + "5555")));
+            }
+
+            return value(r);
+        });
+    }
+
+    @SuppressWarnings("all")
+    private static int mapBoundRange(int a1, int a2, int b1, int b2, int s) {
+        return min(b2, max(b1, b1 + ((s - a1) * (b2 - b1)) / (a2 - a1)));
+    }
+}

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -22,7 +22,6 @@ public class PlaceholdersWrapper {
     public static final Identifier FACTION_POWER_FORMATTED_ID = new Identifier(MODID, "power_formatted");
     public static final Identifier FACTION_MAX_POWER_ID = new Identifier(MODID, "max_power");
     public static final Identifier FACTION_PLAYER_POWER_ID = new Identifier(MODID, "player_power");
-    public static final Identifier FACTION_PLAYER_MAX_POWER_ID = new Identifier(MODID, "player_max_power");
     public static final Identifier FACTION_REQUIRED_POWER_ID = new Identifier(MODID, "required_power");
     public static final Identifier FACTION_REQUIRED_POWER_FORMATTED_ID = new Identifier(MODID, "required_power_formatted");
     public static final String NULL_STRING = "N/A";
@@ -110,8 +109,6 @@ public class PlaceholdersWrapper {
             final var faction = member.getFaction();
 
             if (faction != null) {
-//              TODO(samu): import per-player power patch
-//              FIXME(samu): Using normal max power formula instead of per-player max power
                 final int red = mapBoundRange(faction.calculateMaxPower(), 0, 170, 255, faction.getPower());
                 final int green = mapBoundRange(0, faction.calculateMaxPower(), 170, 255, faction.getPower());
                 r = Text.literal("" + faction.getPower()).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + toHexString(green) + "AA")));
@@ -131,34 +128,13 @@ public class PlaceholdersWrapper {
 
             final var faction = member.getFaction();
 
-//          TODO(samu): import per-player power patch
-//          FIXME(samu): Using normal max power formula instead of per-player max power
             if (faction != null) r = "" + faction.calculateMaxPower();
 
             return value(r);
         });
 
         register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
-            if (!ctx.hasPlayer()) return invalid("No Player!");
-            assert ctx.player() != null;
-
-            final var member = User.get(ctx.player().getUuid());
-            if (member == null) return value("" + User.getPower(ctx.player().getUuid()));
-
-            String r = "" + member.getPower();
-
-            return value(r);
-        });
-
-        register(FACTION_PLAYER_MAX_POWER_ID, (ctx, argument) -> {
-            if (!ctx.hasPlayer()) return invalid("No Player!");
-            assert ctx.player() != null;
-
-            final var member = User.get(ctx.player().getUuid());
-            if (member == null) return value("" + User.getMaxPower(ctx.player().getUuid()));
-
-            String r = "" + member.getMaxPower();
-
+            String r = "" + FactionsMod.CONFIG.MEMBER_POWER;
             return value(r);
         });
 

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -134,7 +134,7 @@ public class PlaceholdersWrapper {
         });
 
         register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
-            String r = "" + FactionsMod.CONFIG.MEMBER_POWER;
+            String r = "" + FactionsMod.CONFIG.POWER.MEMBER;
             return value(r);
         });
 
@@ -150,7 +150,7 @@ public class PlaceholdersWrapper {
             final var faction = member.getFaction();
 
             if (faction != null)
-                r = "" + faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+                r = "" + faction.getClaims().size() * FactionsMod.CONFIG.POWER.CLAIM_WEIGHT;
 
             return value(r);
         });
@@ -168,7 +168,7 @@ public class PlaceholdersWrapper {
 
 
             if (faction != null) {
-                final int reqPower = faction.getClaims().size() * FactionsMod.CONFIG.CLAIM_WEIGHT;
+                final int reqPower = faction.getClaims().size() * FactionsMod.CONFIG.POWER.CLAIM_WEIGHT;
                 final int red = mapBoundRange(0, faction.getPower(), 85, 255, reqPower);
                 r = Text.literal("" + reqPower).setStyle(Style.EMPTY.withColor(TextColor.parse("#" + toHexString(red) + "5555")));
             }

--- a/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
+++ b/src/main/java/io/icker/factions/util/PlaceholdersWrapper.java
@@ -21,7 +21,8 @@ public class PlaceholdersWrapper {
     public static final Identifier FACTION_POWER_ID = new Identifier(MODID, "power");
     public static final Identifier FACTION_POWER_FORMATTED_ID = new Identifier(MODID, "power_formatted");
     public static final Identifier FACTION_MAX_POWER_ID = new Identifier(MODID, "max_power");
-    public static final Identifier FACTION_PLAYER_POWER_ID = new Identifier(MODID, "player_power");
+//    public static final Identifier FACTION_PLAYER_POWER_ID = new Identifier(MODID, "player_power");
+    public static final Identifier FACTION_PLAYER_MAX_POWER_ID = new Identifier(MODID, "player_max_power");
     public static final Identifier FACTION_REQUIRED_POWER_ID = new Identifier(MODID, "required_power");
     public static final Identifier FACTION_REQUIRED_POWER_FORMATTED_ID = new Identifier(MODID, "required_power_formatted");
     public static final String NULL_STRING = "N/A";
@@ -133,8 +134,29 @@ public class PlaceholdersWrapper {
             return value(r);
         });
 
-        register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
-            String r = "" + FactionsMod.CONFIG.POWER.MEMBER;
+//        register(FACTION_PLAYER_POWER_ID, (ctx, argument) -> {
+//            if (!ctx.hasPlayer()) return invalid("No Player!");
+//            assert ctx.player() != null;
+//
+//            final var member = User.get(ctx.player().getUuid());
+////            if (member == null) return value("" + User.getPower(ctx.player().getUuid()));
+//            if (member == null) return value("" + User.getMaxPower(ctx.player().getUuid()));
+//
+////            String r = "" + member.getPower();
+//            String r = "" + member.getMaxPower();
+//
+//            return value(r);
+//        });
+
+        register(FACTION_PLAYER_MAX_POWER_ID, (ctx, argument) -> {
+            if (!ctx.hasPlayer()) return invalid("No Player!");
+            assert ctx.player() != null;
+
+            final var member = User.get(ctx.player().getUuid());
+            if (member == null) return value("" + User.getMaxPower(ctx.player().getUuid()));
+
+            String r = "" + member.getMaxPower();
+
             return value(r);
         });
 


### PR DESCRIPTION
Before working more on this I'd like to discuss various implementations of this.

For now I just added a way to modify via LuckPerms how much power can each user have via `factions.power.modifier.<number>`, but we can go further by moving the `power` attribute from the `Faction` to the `User` and add methods to calculate and manipulate power in a faction (it would be similar to this branch' `Faction#calculateMaxPower`).

I'd like to hear your point of view on this change.

(also this branch is based on [CamperSamu:placeholders-patch](https://github.com/CamperSamu/factions/tree/placeholders-patch) since some work is needed on the placeholders too)