### PR TITLE
Update CreateCommand.java

### DIFF
--- a/src/main/java/io/icker/factions/command/CreateCommand.java
+++ b/src/main/java/io/icker/factions/command/CreateCommand.java
@@ -28,7 +28,7 @@ public class CreateCommand implements Command {
             return 0;
         }
 
-        if (FactionsMod.CONFIG.DISPLAY.NAME_MAX_LENGTH >= 0 & FactionsMod.CONFIG.DISPLAY.NAME_MAX_LENGTH > name.length()) {
+        if (FactionsMod.CONFIG.DISPLAY.NAME_MAX_LENGTH >= 0 & FactionsMod.CONFIG.DISPLAY.NAME_MAX_LENGTH < name.length()) {
             new Message("Cannot create a faction with this name as it is too long").fail().send(player, false);
             return 0;
         }


### PR DESCRIPTION
Fixed incorrect comparison of NAME_MAX_LENGTH and actual name length that lead to players being unable to create factions with shorter names than the cap.