### PR TITLE
ClassCastException fix for LAN games

### DIFF
--- a/src/main/java/io/icker/factions/core/InteractionManager.java
+++ b/src/main/java/io/icker/factions/core/InteractionManager.java
@@ -22,7 +22,6 @@ import net.minecraft.item.BucketItem;
 import net.minecraft.item.Item;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsageContext;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.Hand;
 import net.minecraft.util.TypedActionResult;

--- a/src/main/java/io/icker/factions/core/InteractionManager.java
+++ b/src/main/java/io/icker/factions/core/InteractionManager.java
@@ -49,7 +49,7 @@ public class InteractionManager {
     private static boolean onBreakBlock(World world, PlayerEntity player, BlockPos pos, BlockState state, BlockEntity blockEntity) {
         boolean result = checkPermissions(player, pos, world, Permissions.BREAK_BLOCKS) == ActionResult.FAIL;
         if (result) {
-            InteractionsUtil.warn((ServerPlayerEntity) player, "break blocks");
+            InteractionsUtil.warn(player, "break blocks");
         }
         return !result;
     }
@@ -59,14 +59,14 @@ public class InteractionManager {
 
         BlockPos hitPos = hitResult.getBlockPos();
         if (checkPermissions(player, hitPos, world, Permissions.USE_BLOCKS) == ActionResult.FAIL) {
-            InteractionsUtil.warn((ServerPlayerEntity) player, "use blocks");
+            InteractionsUtil.warn(player, "use blocks");
             InteractionsUtil.sync(player, stack, hand);
             return ActionResult.FAIL;
         }
 
         BlockPos placePos = hitPos.add(hitResult.getSide().getVector());
         if (checkPermissions(player, placePos, world, Permissions.USE_BLOCKS) == ActionResult.FAIL) {
-            InteractionsUtil.warn((ServerPlayerEntity) player, "use blocks");
+            InteractionsUtil.warn(player, "use blocks");
             InteractionsUtil.sync(player, stack, hand);
             return ActionResult.FAIL;
         }
@@ -76,7 +76,7 @@ public class InteractionManager {
 
     private static ActionResult onPlaceBlock(ItemUsageContext context) {
         if (checkPermissions(context.getPlayer(), context.getBlockPos(), context.getWorld(), Permissions.PLACE_BLOCKS) == ActionResult.FAIL) {
-            InteractionsUtil.warn((ServerPlayerEntity) context.getPlayer(), "place blocks");
+            InteractionsUtil.warn(context.getPlayer(), "place blocks");
             InteractionsUtil.sync(context.getPlayer(), context.getStack(), context.getHand());
             return ActionResult.FAIL;
         }
@@ -90,7 +90,7 @@ public class InteractionManager {
         if (item instanceof BucketItem) {
             ActionResult playerResult = checkPermissions(player, player.getBlockPos(), world, Permissions.PLACE_BLOCKS);
             if (playerResult == ActionResult.FAIL) {
-                InteractionsUtil.warn((ServerPlayerEntity) player, "pick up/place liquids");
+                InteractionsUtil.warn(player, "pick up/place liquids");
                 InteractionsUtil.sync(player, player.getStackInHand(hand), hand);
                 return TypedActionResult.fail(player.getStackInHand(hand));
             }
@@ -103,14 +103,14 @@ public class InteractionManager {
             if (raycastResult.getType() != BlockHitResult.Type.MISS) {
                 BlockPos raycastPos = raycastResult.getBlockPos();
                 if (checkPermissions(player, raycastPos, world, Permissions.PLACE_BLOCKS) == ActionResult.FAIL) {
-                    InteractionsUtil.warn((ServerPlayerEntity) player, "pick up/place liquids");
+                    InteractionsUtil.warn(player, "pick up/place liquids");
                     InteractionsUtil.sync(player, player.getStackInHand(hand), hand);
                     return TypedActionResult.fail(player.getStackInHand(hand));
                 }
 
                 BlockPos placePos = raycastPos.add(raycastResult.getSide().getVector());
                 if (checkPermissions(player, placePos, world, Permissions.PLACE_BLOCKS) == ActionResult.FAIL) {
-                    InteractionsUtil.warn((ServerPlayerEntity) player, "pick up/place liquids");
+                    InteractionsUtil.warn(player, "pick up/place liquids");
                     InteractionsUtil.sync(player, player.getStackInHand(hand), hand);
                     return TypedActionResult.fail(player.getStackInHand(hand));
                 }
@@ -123,7 +123,7 @@ public class InteractionManager {
 
     private static ActionResult onAttackEntity(PlayerEntity player, World world, Hand hand, Entity entity, EntityHitResult hitResult) {
         if (entity != null && checkPermissions(player, entity.getBlockPos(), world, Permissions.ATTACK_ENTITIES) == ActionResult.FAIL) {
-            InteractionsUtil.warn((ServerPlayerEntity) player, "attack entities");
+            InteractionsUtil.warn(player, "attack entities");
             return ActionResult.FAIL;
         }
 
@@ -132,7 +132,7 @@ public class InteractionManager {
 
     private static ActionResult onUseEntity(PlayerEntity player, Entity entity, World world) {
         if (checkPermissions(player, entity.getBlockPos(), world, Permissions.USE_ENTITIES) == ActionResult.FAIL) {
-            InteractionsUtil.warn((ServerPlayerEntity) player, "use entities");
+            InteractionsUtil.warn(player, "use entities");
             return ActionResult.FAIL;
         }
 
@@ -141,7 +141,7 @@ public class InteractionManager {
 
     private static ActionResult onUseInventory(PlayerEntity player, BlockPos pos, World world) {
         if (checkPermissions(player, pos, world, Permissions.USE_INVENTORIES) == ActionResult.FAIL) {
-            InteractionsUtil.warn((ServerPlayerEntity) player, "use inventories");
+            InteractionsUtil.warn(player, "use inventories");
             return ActionResult.FAIL;
         }
 

--- a/src/main/java/io/icker/factions/core/InteractionsUtil.java
+++ b/src/main/java/io/icker/factions/core/InteractionsUtil.java
@@ -20,7 +20,7 @@ public class InteractionsUtil {
         }
     }
 
-    public static void warn(ServerPlayerEntity player, String action) {
+    public static void warn(PlayerEntity player, String action) {
         SoundManager.warningSound(player);
         User user = User.get(player.getUuid());
         new Message(

--- a/src/main/java/io/icker/factions/core/InteractionsUtil.java
+++ b/src/main/java/io/icker/factions/core/InteractionsUtil.java
@@ -4,7 +4,6 @@ import io.icker.factions.api.persistents.User;
 import io.icker.factions.util.Message;
 import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.item.ItemStack;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.util.Hand;
 
 public class InteractionsUtil {

--- a/src/main/java/io/icker/factions/core/SoundManager.java
+++ b/src/main/java/io/icker/factions/core/SoundManager.java
@@ -24,17 +24,17 @@ public class SoundManager {
 
     private static void playFaction(Faction faction, RegistryEntry.Reference<SoundEvent> soundEvent, float pitch) {
         for (User user : faction.getUsers()) {
-            ServerPlayerEntity player = FactionsManager.playerManager.getPlayer(user.getID());
+            PlayerEntity player = FactionsManager.playerManager.getPlayer(user.getID());
             if (player != null && (user.sounds == User.SoundMode.ALL || user.sounds == User.SoundMode.FACTION)) {
                 player.playSound(soundEvent.value(), SoundCategory.PLAYERS, 0.2F, pitch);
             }
         }
     }
 
-    public static void warningSound(ServerPlayerEntity player) {
+    public static void warningSound(PlayerEntity player) {
         User user = User.get(player.getUuid());
         if (user.sounds == User.SoundMode.ALL || user.sounds == User.SoundMode.WARNINGS) {
-            player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_BASS.value(), SoundCategory.PLAYERS, 0.5F, 1.0F);
+        	player.playSound(SoundEvents.BLOCK_NOTE_BLOCK_BASS.value(), SoundCategory.PLAYERS, 0.5F, 1.0F);
         }
     }
 }

--- a/src/main/java/io/icker/factions/core/SoundManager.java
+++ b/src/main/java/io/icker/factions/core/SoundManager.java
@@ -6,7 +6,6 @@ import io.icker.factions.api.persistents.Faction;
 import io.icker.factions.api.persistents.User;
 import net.minecraft.registry.entry.RegistryEntry;
 import net.minecraft.server.PlayerManager;
-import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;
 import net.minecraft.sound.SoundEvents;

--- a/src/main/java/io/icker/factions/core/SoundManager.java
+++ b/src/main/java/io/icker/factions/core/SoundManager.java
@@ -5,6 +5,7 @@ import io.icker.factions.api.events.FactionEvents;
 import io.icker.factions.api.persistents.Faction;
 import io.icker.factions.api.persistents.User;
 import net.minecraft.registry.entry.RegistryEntry;
+import net.minecraft.entity.player.PlayerEntity;
 import net.minecraft.server.PlayerManager;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvent;


### PR DESCRIPTION
This change will fix the ClassCastException that was caused by the unchecked cast from PlayerEntity to ServerPlayerEntity which resulted in LAN games to a crash on the server side.