### PR TITLE
use defaultGuestPermissions from config

### DIFF
--- a/src/main/java/io/icker/factions/api/persistents/Relationship.java
+++ b/src/main/java/io/icker/factions/api/persistents/Relationship.java
@@ -3,6 +3,7 @@ package io.icker.factions.api.persistents;
 import java.util.ArrayList;
 import java.util.UUID;
 import io.icker.factions.database.Field;
+import io.icker.factions.FactionsMod;
 
 public class Relationship {
     public enum Status {
@@ -20,7 +21,7 @@ public class Relationship {
     public Status status;
 
     @Field("Permissions")
-    public ArrayList<Permissions> permissions = new ArrayList<>();
+    public ArrayList<Permissions> permissions = new ArrayList<>(FactionsMod.CONFIG.RELATIONSHIPS.DEFAULT_GUEST_PERMISSIONS);
 
     public Relationship(UUID target, Status status) {
         this.target = target;

--- a/src/main/java/io/icker/factions/core/InteractionManager.java
+++ b/src/main/java/io/icker/factions/core/InteractionManager.java
@@ -211,8 +211,12 @@ public class InteractionManager {
             return ActionResult.PASS;
         }
 
-        if (!user.isInFaction()) {
-            return ActionResult.FAIL;
+        if (!user.isInFaction()){
+            if (claimFaction.guest_permissions.contains(permission)) {
+                return ActionResult.SUCCESS;
+            }else{
+                return ActionResult.FAIL;
+            }
         }
 
         Faction userFaction = user.getFaction();


### PR DESCRIPTION
makes it so that relationships to new factions are initialized to defaultGuestPermissions.
also makes it so that when someone isn't in any faction, they have defaultGuestPermissions on faction land.