### PR TITLE
Enhance inventory serialization and improve player movement

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A faction's power cap increases as new members join, expanding their ability to 
 
 &nbsp;
 
-### **GET STARTED**
+### **GET STARTED** 
 
 Factions Mod is very intuitive and works immediately after installation, requiring no additional configuration. However, you can read further about the mod on the [Wiki][wiki]. Our wiki goes in depth about the factions mechanics, its configuration, commands and integrations.
 

--- a/src/main/java/io/icker/factions/core/WorldManager.java
+++ b/src/main/java/io/icker/factions/core/WorldManager.java
@@ -29,7 +29,7 @@ public class WorldManager {
         ServerLevel world = (ServerLevel) player.level();
         String dimension = world.dimension().identifier().toString();
 
-        ChunkPos chunkPos = world.getChunk(player.blockPosition()).getPos();
+        ChunkPos chunkPos = player.chunkPosition();
 
         Claim claim = Claim.get(chunkPos.x(), chunkPos.z(), dimension);
         if (user.autoclaim && claim == null) {

--- a/src/main/java/io/icker/factions/database/SerializerRegistry.java
+++ b/src/main/java/io/icker/factions/database/SerializerRegistry.java
@@ -11,6 +11,7 @@ import io.icker.factions.api.persistents.User.Rank;
 import io.icker.factions.api.persistents.User.SoundMode;
 import io.icker.factions.util.WorldUtils;
 
+import net.minecraft.core.RegistryAccess;
 import net.minecraft.core.UUIDUtil;
 import net.minecraft.nbt.ByteArrayTag;
 import net.minecraft.nbt.ByteTag;
@@ -146,6 +147,17 @@ public class SerializerRegistry {
                 el -> Enum.valueOf(clazz, el.asString().orElse("")));
     }
 
+    private static RegistryAccess resolveRegistryAccess() {
+        var world = WorldUtils.getWorld("minecraft:overworld");
+        if (world != null) {
+            return world.registryAccess();
+        }
+        if (WorldUtils.server != null) {
+            return WorldUtils.server.registryAccess();
+        }
+        return null;
+    }
+
     public record InventoryItem(int slot, ItemStack stack) {
         public static final Codec<InventoryItem> CODEC =
                 RecordCodecBuilder.create(
@@ -165,12 +177,16 @@ public class SerializerRegistry {
     private static Serializer<SimpleContainer, ListTag> createInventorySerializer(int size) {
         return new Serializer<SimpleContainer, ListTag>(
                 val -> {
+                    RegistryAccess registryAccess = resolveRegistryAccess();
+                    if (registryAccess == null) {
+                        FactionsMod.LOGGER.error(
+                                "Registry access unavailable; skipping inventory serialization.");
+                        return new ListTag();
+                    }
                     ProblemReporter.ScopedCollector reporter =
                             new ProblemReporter.ScopedCollector(FactionsMod.LOGGER);
                     TagValueOutput view =
-                            TagValueOutput.createWithContext(
-                                    reporter,
-                                    WorldUtils.getWorld("minecraft:overworld").registryAccess());
+                            TagValueOutput.createWithContext(reporter, registryAccess);
                     TypedOutputList<InventoryItem> appender =
                             view.list("Data", InventoryItem.CODEC);
 
@@ -186,6 +202,17 @@ public class SerializerRegistry {
                     return view.buildResult().getList("Data").get();
                 },
                 el -> {
+                    RegistryAccess registryAccess = resolveRegistryAccess();
+                    SimpleContainer inventory = new SimpleContainer(size);
+                    for (int i = 0; i < size; ++i) {
+                        inventory.setItem(i, ItemStack.EMPTY);
+                    }
+                    if (registryAccess == null) {
+                        FactionsMod.LOGGER.error(
+                                "Registry access unavailable; skipping inventory deserialization.");
+                        return inventory;
+                    }
+
                     CompoundTag compound = new CompoundTag();
                     compound.put("Data", el);
 
@@ -193,16 +220,7 @@ public class SerializerRegistry {
                             new ProblemReporter.ScopedCollector(FactionsMod.LOGGER);
 
                     ValueInput view =
-                            TagValueInput.create(
-                                    reporter,
-                                    WorldUtils.getWorld("minecraft:overworld").registryAccess(),
-                                    compound);
-
-                    SimpleContainer inventory = new SimpleContainer(size);
-
-                    for (int i = 0; i < size; ++i) {
-                        inventory.setItem(i, ItemStack.EMPTY);
-                    }
+                            TagValueInput.create(reporter, registryAccess, compound);
 
                     TypedInputList<InventoryItem> list_view =
                             view.listOrEmpty("Data", InventoryItem.CODEC);

--- a/src/main/java/io/icker/factions/mixin/ServerGamePacketListenerImplMixin.java
+++ b/src/main/java/io/icker/factions/mixin/ServerGamePacketListenerImplMixin.java
@@ -21,9 +21,19 @@ import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 public class ServerGamePacketListenerImplMixin {
     @Shadow public ServerPlayer player;
 
-    @Inject(method = "handleMovePlayer", at = @At("HEAD"))
+    @Inject(method = "handleMovePlayer", at = @At("TAIL"))
     public void handleMovePlayer(ServerboundMovePlayerPacket packet, CallbackInfo ci) {
-        PlayerEvents.ON_MOVE.invoker().onMove(player);
+        if (player == null) return;
+        if (player.level() == null) return;
+
+        var server = player.level().getServer();
+        if (server == null) return;
+
+        if (server.isSameThread()) {
+            PlayerEvents.ON_MOVE.invoker().onMove(player);
+        } else {
+            server.execute(() -> PlayerEvents.ON_MOVE.invoker().onMove(player));
+        }
     }
 
     @Inject(method = "broadcastChatMessage", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
This pull request improves the reliability and safety of inventory serialization and player movement event handling in the codebase. The main focus is on ensuring that registry access is always available before performing serialization/deserialization, and that player movement events are triggered on the correct server thread to avoid concurrency issues.

**Inventory Serialization Improvements:**

* Added a `resolveRegistryAccess()` helper to safely obtain `RegistryAccess` from the current world or server, with error logging if unavailable. This prevents null pointer exceptions during inventory serialization/deserialization.
* Updated the inventory serializer and deserializer in `SerializerRegistry.java` to check for valid registry access before proceeding, logging errors and skipping the operation if access is unavailable. [[1]](diffhunk://#diff-a70621d4fad09baf5eab2756240da808701219ffa55fd2dc800e77e7bdbe12baR180-R189) [[2]](diffhunk://#diff-a70621d4fad09baf5eab2756240da808701219ffa55fd2dc800e77e7bdbe12baR205-R223)

**Player Movement Event Handling:**

* Changed the injection point for handling player movement in `ServerGamePacketListenerImplMixin.java` to the end of the method (`@At("TAIL")`) and ensured that the `onMove` event is invoked on the main server thread, scheduling it if necessary. This prevents potential threading issues.
* Updated `onMove` in `WorldManager.java` to use `player.chunkPosition()` instead of retrieving the chunk from the world, simplifying and possibly optimizing chunk position retrieval.

**Dependency Management:**

* Added an import for `RegistryAccess` in `SerializerRegistry.java` to support the new registry resolution logic.